### PR TITLE
[Feat/ExchangeRequest] 교환요청 CRUD

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
@@ -1,0 +1,68 @@
+package com.sparta.spartatigers.domain.exchangerequest.controller;
+
+import com.sparta.spartatigers.domain.auth.model.TokenClaim;
+import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.request.UpdateExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
+import com.sparta.spartatigers.domain.exchangerequest.service.ExchangeRequestService;
+import com.sparta.spartatigers.global.aop.Auth;
+import com.sparta.spartatigers.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/exchanges")
+public class ExchangeRequestController {
+
+    private final ExchangeRequestService exchangeRequestService;
+
+    @PostMapping
+    public ApiResponse<?> createExchangeRequest(@Valid @RequestBody ExchangeRequestDto request,
+        @Auth TokenClaim tokenClaim) {
+
+        exchangeRequestService.createExchangeRequest(request, tokenClaim);
+
+        return ApiResponse.success(null);
+    }
+
+    @GetMapping("/receive")
+    public ApiResponse<Page<ReceiveRequestResponseDto>> findAllReceiveRequest(
+        @Auth TokenClaim tokenClaim,
+        @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+        Page<ReceiveRequestResponseDto> response = exchangeRequestService.findAllReceiveRequest(
+            tokenClaim, pageable);
+
+        return ApiResponse.success(response);
+    }
+
+    @PatchMapping("/{exchangeRequestId}")
+    public ApiResponse<?> updateRequestStatus(@PathVariable Long exchangeRequestId,
+        @Valid @RequestBody UpdateExchangeRequestDto request, @Auth TokenClaim tokenClaim) {
+
+        exchangeRequestService.updateRequestStatus(exchangeRequestId, request, tokenClaim);
+
+        return ApiResponse.success(null);
+    }
+
+    @PatchMapping("/{exchangeRequestId}/complete")
+    public ApiResponse<?> completeExchange(@PathVariable Long exchangeRequestId,
+        @Auth TokenClaim tokenClaim) {
+
+        exchangeRequestService.completeExchange(exchangeRequestId, tokenClaim);
+
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/request/ExchangeRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/request/ExchangeRequestDto.java
@@ -1,0 +1,10 @@
+package com.sparta.spartatigers.domain.exchangerequest.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ExchangeRequestDto(
+    @NotNull(message = "요청 받을 사람의 아이디는 필수입니다.") Long receiverId,
+    @NotNull(message = "교환하고 싶은 아이템 아이디 입력은 필수입니다.") Long itemId
+) {
+
+}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/request/UpdateExchangeRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/request/UpdateExchangeRequestDto.java
@@ -1,0 +1,7 @@
+package com.sparta.spartatigers.domain.exchangerequest.dto.request;
+
+import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateExchangeRequestDto(
+        @NotNull(message = "변경할 상태값은 필수입니다.") ExchangeStatus status) {}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ReceiveRequestResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ReceiveRequestResponseDto.java
@@ -1,0 +1,29 @@
+package com.sparta.spartatigers.domain.exchangerequest.dto.response;
+
+import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeRequest;
+import com.sparta.spartatigers.domain.item.model.ItemCategory;
+import com.sparta.spartatigers.domain.item.model.ItemStatus;
+import com.sparta.spartatigers.domain.user.dto.UserResponseDto;
+import java.time.LocalDateTime;
+
+public record ReceiveRequestResponseDto(
+    Long exchangeRequestId,
+    Long itemId,
+    UserResponseDto sender,
+    ItemCategory category,
+    String title,
+    ItemStatus status,
+    LocalDateTime createdAt) {
+
+    public static ReceiveRequestResponseDto from(ExchangeRequest exchangeRequest) {
+
+        return new ReceiveRequestResponseDto(
+            exchangeRequest.getId(),
+            exchangeRequest.getItem().getId(),
+            UserResponseDto.from(exchangeRequest.getSender()),
+            exchangeRequest.getItem().getCategory(),
+            exchangeRequest.getItem().getTitle(),
+            exchangeRequest.getItem().getStatus(),
+            exchangeRequest.getCreatedAt());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/ExchangeRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/ExchangeRequest.java
@@ -3,6 +3,8 @@ package com.sparta.spartatigers.domain.exchangerequest.model;
 import com.sparta.spartatigers.domain.common.entity.BaseEntity;
 import com.sparta.spartatigers.domain.item.model.Item;
 import com.sparta.spartatigers.domain.user.model.User;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.ServerException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -35,4 +37,30 @@ public class ExchangeRequest extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ExchangeStatus status;
 
+    public ExchangeRequest(Item item, User sender, User receiver, ExchangeStatus exchangeStatus) {
+        this.item = item;
+        this.sender = sender;
+        this.receiver = receiver;
+        this.status = exchangeStatus;
+    }
+
+    public static ExchangeRequest of(Item item, User sender, User receiver) {
+
+        return new ExchangeRequest(item, sender, receiver, ExchangeStatus.PENDING);
+    }
+
+    public void validateReceiverIsOwner(User receiver) {
+
+        if (!this.receiver.getId().equals(receiver.getId())) {
+            throw new ServerException(ExceptionCode.RECEIVER_FORBIDDEN);
+        }
+    }
+
+    public void updateStatus(ExchangeStatus status) {
+        this.status = status;
+    }
+
+    public void complete() {
+        this.status = ExchangeStatus.COMPLETED;
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestRepository.java
@@ -1,0 +1,35 @@
+package com.sparta.spartatigers.domain.exchangerequest.repository;
+
+import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeRequest;
+import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeStatus;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.ServerException;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ExchangeRequestRepository extends JpaRepository<ExchangeRequest, Long> {
+
+    boolean existsBySenderIdAndReceiverIdAndItemId(Long senderId, Long receiverId, Long itemId);
+
+    @EntityGraph(attributePaths = {"receiver", "sender", "item"})
+    @Query("select e from exchange_request e where e.receiver.id = :receiverId")
+    Page<ExchangeRequest> findAllReceiveRequest(@Param("receiverId") Long receiverId, Pageable pageable);
+
+    Optional<ExchangeRequest> findByIdAndStatus(
+        Long exchangeRequestId, ExchangeStatus status);
+
+    default ExchangeRequest findExchangeRequestByIdOrElseThrow(Long exchangeRequestId) {
+        return findByIdAndStatus(exchangeRequestId, ExchangeStatus.PENDING)
+            .orElseThrow(() -> new ServerException(ExceptionCode.EXCHANGE_REQUEST_NOT_FOUND));
+    }
+
+    default ExchangeRequest findAcceptedRequestByIdOrElseThrow(Long exchangeRequestId) {
+        return findByIdAndStatus(exchangeRequestId, ExchangeStatus.ACCEPTED)
+            .orElseThrow(() -> new ServerException(ExceptionCode.EXCHANGE_REQUEST_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -1,0 +1,106 @@
+package com.sparta.spartatigers.domain.exchangerequest.service;
+
+import com.sparta.spartatigers.domain.auth.model.TokenClaim;
+import com.sparta.spartatigers.domain.directRoom.service.DirectRoomService;
+import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.request.UpdateExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
+import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeRequest;
+import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeStatus;
+import com.sparta.spartatigers.domain.exchangerequest.repository.ExchangeRequestRepository;
+import com.sparta.spartatigers.domain.item.model.Item;
+import com.sparta.spartatigers.domain.item.repository.ItemRepository;
+import com.sparta.spartatigers.domain.user.model.User;
+import com.sparta.spartatigers.domain.user.repository.UserRepository;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.InvalidRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangeRequestService {
+
+    private final ExchangeRequestRepository exchangeRequestRepository;
+    private final DirectRoomService directRoomService;
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+
+    @Transactional
+    public void createExchangeRequest(ExchangeRequestDto request, TokenClaim tokenClaim) {
+
+        User sender = getUser(tokenClaim.getUserId());
+        User receiver = getUser(request.receiverId());
+        Item item = itemRepository.findByIdWithLockOrElseThrow(request.itemId());
+
+        item.validateSenderIsNotOwner(sender);
+        item.validateReceiverIsOwner(receiver);
+
+        checkDuplicateExchangeRequest(sender.getId(), receiver.getId(), item.getId());
+
+        ExchangeRequest exchangeRequest = ExchangeRequest.of(item, sender, receiver);
+        exchangeRequestRepository.save(exchangeRequest);
+    }
+
+    public Page<ReceiveRequestResponseDto> findAllReceiveRequest(TokenClaim tokenClaim, Pageable pageable) {
+
+        User user = getUser(tokenClaim.getUserId());
+        Page<ExchangeRequest> exchangeRequestList = exchangeRequestRepository.findAllReceiveRequest(
+            user.getId(), pageable);
+
+        return exchangeRequestList.map(ReceiveRequestResponseDto::from);
+    }
+
+    @Transactional
+    public void updateRequestStatus(Long exchangeRequestId, UpdateExchangeRequestDto request,
+        TokenClaim tokenClaim) {
+
+        User user = getUser(tokenClaim.getUserId());
+        ExchangeRequest exchangeRequest = exchangeRequestRepository.findExchangeRequestByIdOrElseThrow(
+            exchangeRequestId);
+        exchangeRequest.validateReceiverIsOwner(user);
+        exchangeRequest.updateStatus(request.status());
+
+        if (exchangeRequest.getStatus() == ExchangeStatus.ACCEPTED) {
+            directRoomService.createRoom(exchangeRequestId, user.getId());
+        }
+
+        if (exchangeRequest.getStatus() == ExchangeStatus.REJECTED) {
+            exchangeRequestRepository.delete(exchangeRequest);
+        }
+    }
+
+    @Transactional
+    public void completeExchange(Long exchangeRequestId, TokenClaim tokenClaim) {
+
+        User user = getUser(tokenClaim.getUserId());
+        ExchangeRequest exchangeRequest = exchangeRequestRepository.findAcceptedRequestByIdOrElseThrow(
+            exchangeRequestId);
+        exchangeRequest.validateReceiverIsOwner(user);
+
+        Item item = itemRepository.findById(exchangeRequest.getItem().getId())
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ITEM_NOT_FOUND));
+        item.complete();
+
+        exchangeRequest.complete();
+    }
+
+    private User getUser(Long userId) {
+
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.USER_NOT_FOUND));
+    }
+
+    private void checkDuplicateExchangeRequest(Long senderId, Long receiverId, Long itemId) {
+
+        boolean isExisted =
+            exchangeRequestRepository.existsBySenderIdAndReceiverIdAndItemId(senderId, receiverId, itemId);
+
+        if (isExisted) {
+            throw new InvalidRequestException(ExceptionCode.EXCHANGE_REQUEST_DUPLICATED);
+        }
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemDetailResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemDetailResponseDto.java
@@ -3,12 +3,12 @@ package com.sparta.spartatigers.domain.item.dto.response;
 import com.sparta.spartatigers.domain.item.model.Item;
 import com.sparta.spartatigers.domain.item.model.ItemCategory;
 import com.sparta.spartatigers.domain.item.model.ItemStatus;
+import com.sparta.spartatigers.domain.user.dto.UserResponseDto;
 import java.time.LocalDateTime;
 
 public record ReadItemDetailResponseDto(
     Long id,
-    Long userId,
-    String nickname,
+    UserResponseDto user,
     ItemCategory category,
     String image,
     String seatInfo,
@@ -21,8 +21,7 @@ public record ReadItemDetailResponseDto(
 
         return new ReadItemDetailResponseDto(
             item.getId(),
-            item.getUser().getId(),
-            item.getUser().getNickname(),
+            UserResponseDto.from(item.getUser()),
             item.getCategory(),
             item.getImage(),
             item.getSeatInfo(),

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/response/ReadItemResponseDto.java
@@ -3,19 +3,25 @@ package com.sparta.spartatigers.domain.item.dto.response;
 import com.sparta.spartatigers.domain.item.model.Item;
 import com.sparta.spartatigers.domain.item.model.ItemCategory;
 import com.sparta.spartatigers.domain.item.model.ItemStatus;
+import com.sparta.spartatigers.domain.user.dto.UserResponseDto;
+import java.time.LocalDateTime;
 
 public record ReadItemResponseDto(
     Long id,
-    Long userId,
-    String nickname,
+    UserResponseDto user,
     ItemCategory category,
     String title,
-    ItemStatus status
-) {
+    ItemStatus status,
+    LocalDateTime createdAt) {
 
     public static ReadItemResponseDto from(Item item) {
 
-        return new ReadItemResponseDto(item.getId(), item.getUser().getId(), item.getUser().getNickname(), item.getCategory(),
-            item.getTitle(), item.getStatus());
+        return new ReadItemResponseDto(
+            item.getId(),
+            UserResponseDto.from(item.getUser()),
+            item.getCategory(),
+            item.getTitle(),
+            item.getStatus(),
+            item.getCreatedAt());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/item/model/Item.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/model/Item.java
@@ -135,4 +135,9 @@ public class Item extends BaseEntity {
             this.description = request.description();
         }
     }
+
+    public void complete() {
+        this.status = ItemStatus.COMPLETED;
+        this.createdDate = null;
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemRepository.java
@@ -6,6 +6,7 @@ import com.sparta.spartatigers.global.exception.ExceptionCode;
 import com.sparta.spartatigers.global.exception.InvalidRequestException;
 
 import jakarta.persistence.LockModeType;
+import java.time.LocalDate;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,10 +19,10 @@ import org.springframework.data.repository.query.Param;
 public interface ItemRepository extends JpaRepository<Item, Long> {
 
     @EntityGraph(attributePaths = "user")
-    @Query("select i from items i where i.status = :itemStatus")
-    Page<Item> findAllItems(@Param("itemStatus") ItemStatus itemStatus, Pageable pageable);
+    @Query("select i from items i where i.status = :itemStatus and i.createdDate = :createdDate")
+    Page<Item> findAllItems(@Param("itemStatus") ItemStatus itemStatus, @Param("createdDate") LocalDate createdDate, Pageable pageable);
 
-    Optional<Item> findByIdAndStatus(Long id, ItemStatus itemStatus);
+    Optional<Item> findByIdAndStatusAndCreatedDate(Long id, ItemStatus itemStatus, LocalDate createdDate);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select i from items i where i.id = :id and i.status = :itemStatus")
@@ -31,5 +32,12 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
 
         return findByIdWithLock(id, ItemStatus.REGISTERED)
             .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ITEM_NOT_FOUND));
+    }
+
+    default Item findByIdAndStatusAndDateOrElseThrow(Long id) {
+
+        return findByIdAndStatusAndCreatedDate(id, ItemStatus.REGISTERED,
+            LocalDate.now()).orElseThrow(
+            () -> new InvalidRequestException(ExceptionCode.ITEM_NOT_FOUND));
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
@@ -14,6 +14,7 @@ import com.sparta.spartatigers.domain.user.repository.UserRepository;
 import com.sparta.spartatigers.global.exception.ExceptionCode;
 import com.sparta.spartatigers.global.exception.InvalidRequestException;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -45,8 +46,7 @@ public class ItemService {
         User user = userRepository.findById(tokenClaim.getUserId())
             .orElseThrow(() ->  new InvalidRequestException(ExceptionCode.VALIDATION_ERROR));
 
-        Page<Item> itemList = itemRepository.findAllItems(ItemStatus.REGISTERED,
-            pageable);
+        Page<Item> itemList = itemRepository.findAllItems(ItemStatus.REGISTERED, LocalDate.now(), pageable);
 
         return itemList.map(ReadItemResponseDto::from);
     }
@@ -54,8 +54,7 @@ public class ItemService {
     @Transactional(readOnly = true)
     public ReadItemDetailResponseDto findItemById(Long itemId) {
 
-        Item item = itemRepository.findByIdAndStatus(itemId, ItemStatus.REGISTERED)
-            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ITEM_NOT_FOUND));
+        Item item = itemRepository.findByIdAndStatusAndDateOrElseThrow(itemId);
 
         return ReadItemDetailResponseDto.from(item);
     }
@@ -66,8 +65,7 @@ public class ItemService {
         User user = userRepository.findById(tokenClaim.getUserId())
             .orElseThrow(() ->  new InvalidRequestException(ExceptionCode.VALIDATION_ERROR));
 
-        Item item = itemRepository.findByIdAndStatus(itemId, ItemStatus.REGISTERED)
-            .orElseThrow(() ->  new InvalidRequestException(ExceptionCode.ITEM_NOT_FOUND));
+        Item item = itemRepository.findByIdAndStatusAndDateOrElseThrow(itemId);
         item.validateUserIsOwner(user);
         item.deleteItem();
     }
@@ -78,8 +76,7 @@ public class ItemService {
         User user = userRepository.findById(tokenClaim.getUserId())
             .orElseThrow(() ->  new InvalidRequestException(ExceptionCode.VALIDATION_ERROR));
 
-        Item item = itemRepository.findByIdAndStatus(itemId, ItemStatus.REGISTERED)
-            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ITEM_NOT_FOUND));
+        Item item = itemRepository.findByIdAndStatusAndDateOrElseThrow(itemId);
         item.validateUserIsOwner(user);
         item.updateItem(request);
 

--- a/src/main/java/com/sparta/spartatigers/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,14 @@
+package com.sparta.spartatigers.domain.user.dto;
+
+import com.sparta.spartatigers.domain.user.model.User;
+
+public record UserResponseDto(Long userId, String userNickname) {
+
+    public static UserResponseDto from(User user) {
+        return new UserResponseDto(user.getId(), user.getNickname());
+    }
+
+    public static UserResponseDto from(Long userId, String userNickname) {
+        return new UserResponseDto(userId, userNickname);
+    }
+}


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 교환요청 등록, 받은 요청 조회, 요청 상태 변경, 교환 종료 기능 추가
  - 위치 기능은 제외하고 구현
- Item 조회 시 오늘 날짜의 아이템만 조회 가능하도록 변경
- `UserResponseDto` 추가

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- close #10

## 💬 기타 코멘트
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 교환 요청 기능 추가: 요청 생성, 받은 요청 목록(최신순 페이지네이션), 상태 업데이트(수락/거절), 교환 완료 처리 지원.
- Improvements
  - 아이템 목록/상세에 사용자 정보 묶음, 생성일, 상태, 제목·설명 등 표시 정보 확대.
  - 아이템 조회가 당일 등록된 아이템을 중심으로 더 정확한 결과 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->