### PR TITLE
[feat/liveboard] 그룹 채팅 리팩토링

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/stompchat/Controller/LiveBoardChatController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/stompchat/Controller/LiveBoardChatController.java
@@ -2,11 +2,16 @@ package com.sparta.spartatigers.domain.stompchat.Controller;
 
 import java.security.Principal;
 
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
 import com.sparta.spartatigers.domain.stompchat.Service.ChatService;
 import com.sparta.spartatigers.domain.stompchat.model.ChatMessage;
+import com.sparta.spartatigers.global.exception.WebSocketException;
+import com.sparta.spartatigers.global.response.WebSocketErrorResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,9 +24,26 @@ public class LiveBoardChatController {
 	// 채팅
 	@MessageMapping("/liveboard/send")
 	public void sendMessage(ChatMessage message, Principal principal) {
-
-
 		chatService.sendGroupMessage(message, principal);
+	}
+
+	// 입장
+	@MessageMapping("/liveboard/enter")
+	public void enterLiveBoard(Message<ChatMessage> message, Principal principal) {
+		chatService.enterRoom(message, principal);
+	}
+
+	// 퇴장
+	@MessageMapping("/liveboard/exit")
+	public void exitLiveBoard(Message<ChatMessage> message) {
+		chatService.exitRoom(message);
+	}
+
+	// 예외 처리
+	@MessageExceptionHandler(WebSocketException.class)
+	@SendToUser("/liveboard/errors")
+	public WebSocketErrorResponse handleWebSocketError(WebSocketException e) {
+		return WebSocketErrorResponse.from(e.getCode());
 	}
 
 }

--- a/src/main/java/com/sparta/spartatigers/domain/stompchat/Service/ChatService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/stompchat/Service/ChatService.java
@@ -1,20 +1,28 @@
 package com.sparta.spartatigers.domain.stompchat.Service;
 
 import java.security.Principal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.stereotype.Service;
 
 import com.sparta.spartatigers.domain.directRoom.model.DirectRoom;
 import com.sparta.spartatigers.domain.directRoom.repository.DirectRoomRepository;
+import com.sparta.spartatigers.domain.liveboardroom.model.LiveBoardConnection;
+import com.sparta.spartatigers.domain.liveboardroom.repository.LiveBoardConnectionRepository;
+import com.sparta.spartatigers.domain.stompchat.interceptor.StompPrincipal;
 import com.sparta.spartatigers.domain.stompchat.model.ChatMessage;
 import com.sparta.spartatigers.domain.stompchat.pubsub.RedisChatPublisher;
 import com.sparta.spartatigers.domain.stompchat.pubsub.RedisChatSubscriber;
-import com.sparta.spartatigers.domain.user.model.User;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+import com.sparta.spartatigers.global.exception.InvalidRequestException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -28,20 +36,50 @@ public class ChatService {
 	private final Map<String, ChannelTopic> topics =
 		new ConcurrentHashMap<>(); // 채팅방별 topic
 	private final UserRepository userRepository;
-
+	private final LiveBoardConnectionRepository liveBoardConnectionRepository;
 
 	public void sendGroupMessage(ChatMessage message, Principal principal) {
-		User sender = userRepository.findById(message.getSenderId()).orElseThrow();
+		if (!(principal instanceof StompPrincipal stompPrincipal)) {
+			throw new InvalidRequestException(ExceptionCode.WEBSOCKET_UNAUTHORIZED);
+		}
 
-		ChatMessage sendMessage = ChatMessage.ofLiveBoardRoom(message.getRoomId(),sender.getId(), sender.getNickname(),
-			message.getContent());
+		Long senderId = Long.parseLong(stompPrincipal.getName());
+		String nickname = userRepository.findNicknameById(senderId).orElse("비회원");
+
+		ChatMessage sendMessage = ChatMessage.ofLiveBoardRoom(
+			message.getRoomId(),
+			senderId,
+			nickname,
+			message.getContent()
+		);
 
 		ChannelTopic topic = getOrInitTopic(message.getRoomId());
-		redisChatPublisher.publish(topic,sendMessage);
+		redisChatPublisher.publish(topic, sendMessage);
 	}
 
-	public void sendDirectMessage(ChatMessage message, Principal principal) {
+	public void enterRoom(Message<ChatMessage> message, Principal principal) {
+		// 기본값..
+		Long senderId = null;
+		String nickname = "비회원";
+		if (principal instanceof StompPrincipal stompPrincipal) {
+			senderId = getSenderId(principal);
+			nickname = userRepository.findNicknameById(senderId).orElse("비회원");
+		}
 
+		String globalSessionId = getGlobalSessionId(message);
+		String roomId = message.getPayload().getRoomId();
+
+		LiveBoardConnection connection = LiveBoardConnection.of(
+			globalSessionId, senderId, nickname, roomId, LocalDateTime.now()
+		);
+		liveBoardConnectionRepository.saveConnection(roomId,globalSessionId, connection);
+	}
+
+	public void exitRoom(Message<ChatMessage> message) {
+		String roomId = message.getPayload().getRoomId();
+		String globalSessionId = getGlobalSessionId(message);
+
+		liveBoardConnectionRepository.deleteConnection(roomId,globalSessionId);
 	}
 
 	private ChannelTopic getOrInitTopic(String roomId) {
@@ -55,6 +93,29 @@ public class ChatService {
 	}
 
 	private Long getSenderId(Principal principal){
-		return Long.valueOf(principal.getName());
+		Long senderId;
+		if(principal instanceof StompPrincipal stompPrincipal) {
+			return senderId = Long.parseLong(stompPrincipal.getName());
+		}
+		// TODO : 나중에 소셜 로그인 추가되면 추가하기
+		return null;
 	}
+
+	private String getGlobalSessionId(Message<ChatMessage> message) {
+		SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(message);
+		return accessor.getSessionId();
+	}
+
+	public void handleDisconnect(String globalSessionId) {
+		List<String> roomIds = liveBoardConnectionRepository.findAllRoomIds();
+
+		for (String roomId : roomIds) {
+			Map<Object, Object> connections = liveBoardConnectionRepository.findAllConnections(roomId);
+			if (connections.containsKey(globalSessionId)) {
+				liveBoardConnectionRepository.deleteConnection(roomId, globalSessionId);
+			}
+		}
+	}
+
+
 }

--- a/src/main/java/com/sparta/spartatigers/domain/stompchat/eventlistener/WebSocketEventListener.java
+++ b/src/main/java/com/sparta/spartatigers/domain/stompchat/eventlistener/WebSocketEventListener.java
@@ -1,0 +1,22 @@
+package com.sparta.spartatigers.domain.stompchat.eventlistener;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import com.sparta.spartatigers.domain.stompchat.Service.ChatService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class WebSocketEventListener {
+
+	private final ChatService liveBoardService;
+
+	@EventListener
+	public void handleDisconnect(SessionDisconnectEvent event) {
+		String sessionId = event.getSessionId();
+		liveBoardService.handleDisconnect(sessionId);
+	}
+}

--- a/src/main/java/com/sparta/spartatigers/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/repository/UserRepository.java
@@ -2,6 +2,7 @@ package com.sparta.spartatigers.domain.user.repository;
 
 import com.sparta.spartatigers.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -10,4 +11,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     Optional<User> findByEmail(String email);
+
+    @Query("SELECT u.nickname FROM users u WHERE u.id = :userId")
+    Optional<String> findNicknameById(Long userId);
+
 }

--- a/src/main/java/com/sparta/spartatigers/global/exception/WebSocketException.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/WebSocketException.java
@@ -1,0 +1,13 @@
+package com.sparta.spartatigers.global.exception;
+
+public class WebSocketException extends RuntimeException {
+
+	private final ExceptionCode code;
+
+	public WebSocketException(ExceptionCode code) {
+		super(code.getMessage());
+		this.code = code;
+	}
+
+	public ExceptionCode getCode(){return code;}
+}

--- a/src/main/java/com/sparta/spartatigers/global/response/WebSocketErrorResponse.java
+++ b/src/main/java/com/sparta/spartatigers/global/response/WebSocketErrorResponse.java
@@ -1,0 +1,18 @@
+package com.sparta.spartatigers.global.response;
+
+import com.sparta.spartatigers.global.exception.ExceptionCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class WebSocketErrorResponse {
+
+	private final String errorType;
+	private final String message;
+
+	public static WebSocketErrorResponse from(ExceptionCode code) {
+		return WebSocketErrorResponse.of(code.name(), code.getMessage());
+	}
+}


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [x] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 라이브보드 입퇴장시 메세지는 불필요하므로 서비스단의 publish, getTopic등을 삭제했습니다
- chatmessage로 통합하면서 messageType을 나타내는 enum도 불필요하기에 삭제했습니다

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- #14

## 💬 기타 코멘트
- 기존 코드와 동일합니다..!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 라이브보드 입장/퇴장 STOMP 엔드포인트 추가로 실시간 방 참여/이탈 지원
  - 연결 해제 이벤트 처리로 세션 종료 시 자동 정리 및 안정성 향상
  - 그룹 메시지에 발신자 닉네임 포함으로 가독성 개선
- 버그 수정
  - 사용자별 WebSocket 오류 채널을 통해 명확한 오류 유형/메시지 전달
  - 인증되지 않은 메시지 전송 차단으로 비정상 요청 대응 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->