### PR TITLE
[feat/item] 아이템 교환 요청 알림 기능 구현

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeNotificationService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeNotificationService.java
@@ -1,0 +1,46 @@
+package com.sparta.spartatigers.domain.exchangerequest.service;
+
+import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeRequest;
+import com.sparta.spartatigers.domain.item.model.Item;
+import com.sparta.spartatigers.domain.user.model.User;
+import com.sparta.spartatigers.global.firebase.FCMService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ExchangeNotificationService {
+
+    private final FCMService fcmService;
+
+    public void sendExchangeRequested(ExchangeRequest exchangeRequest) {
+        User receiver = exchangeRequest.getReceiver();
+        User sender = exchangeRequest.getSender();
+        Item item = exchangeRequest.getItem();
+
+        String token = receiver.getFcmToken();
+        if (token == null || token.isBlank()) {
+            return;
+        }
+
+        String title = "새 교환 요청";
+        String body  = String.format("'%s'에 %s님이 교환을 요청했어요.", item.getTitle(), sender.getNickname());
+
+        fcmService.sendMessageToToken(token, title, body);
+    }
+
+    public void sendExchangeAccepted(ExchangeRequest exchangeRequest) {
+        User sender = exchangeRequest.getSender();
+        Item item = exchangeRequest.getItem();
+
+        String token = sender.getFcmToken();
+        if (token == null || token.isBlank()) {
+            return;
+        }
+
+        String title = "교환 요청이 수락되었어요";
+        String body = String.format("'%s'에 대한 교환 요청이 수락되었어요.", item.getTitle());
+
+        fcmService.sendMessageToToken(token, title, body);
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ExchangeRequestService {
 
+    private final ExchangeNotificationService exchangeNotificationService;
     private final ExchangeRequestRepository exchangeRequestRepository;
     private final DirectRoomService directRoomService;
     private final UserRepository userRepository;
@@ -48,6 +49,8 @@ public class ExchangeRequestService {
 
         ExchangeRequest exchangeRequest = ExchangeRequest.of(item, sender, receiver);
         exchangeRequestRepository.save(exchangeRequest);
+
+        exchangeNotificationService.sendExchangeRequested(exchangeRequest);
     }
 
     public Page<ReceiveRequestResponseDto> findAllReceiveRequest(TokenClaim tokenClaim, Pageable pageable) {
@@ -71,6 +74,7 @@ public class ExchangeRequestService {
 
         if (exchangeRequest.getStatus() == ExchangeStatus.ACCEPTED) {
             directRoomService.createRoom(exchangeRequestId, user.getId());
+            exchangeNotificationService.sendExchangeAccepted(exchangeRequest);
         }
 
         if (exchangeRequest.getStatus() == ExchangeStatus.REJECTED) {

--- a/src/main/java/com/sparta/spartatigers/domain/user/model/User.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/model/User.java
@@ -38,7 +38,13 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
+    @Column private String fcmToken;
+
     public void changePassword(final String password) {
         this.password = password;
+    }
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/user/service/UserService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.user.service;
 
+import com.sparta.spartatigers.domain.auth.model.TokenClaim;
+import com.sparta.spartatigers.global.firebase.dto.FcmTokenRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,5 +31,13 @@ public class UserService {
         user.changePassword(hashedPassword);
 
         return userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateFcmToken(TokenClaim tokenClaim, FcmTokenRequest request) {
+        User user = userRepository.findById(tokenClaim.getUserId())
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.USER_NOT_FOUND));
+
+        user.updateFcmToken(request.fcmToken());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/global/firebase/controller/FCMController.java
+++ b/src/main/java/com/sparta/spartatigers/global/firebase/controller/FCMController.java
@@ -1,0 +1,27 @@
+package com.sparta.spartatigers.global.firebase.controller;
+
+import com.sparta.spartatigers.domain.auth.model.TokenClaim;
+import com.sparta.spartatigers.domain.user.service.UserService;
+import com.sparta.spartatigers.global.aop.Auth;
+import com.sparta.spartatigers.global.firebase.dto.FcmTokenRequest;
+import com.sparta.spartatigers.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class FCMController {
+
+    private final UserService userService;
+
+    @PostMapping("/fcm-token")
+    public ApiResponse<Void> saveFcmToken(@Auth TokenClaim tokenClaim, @RequestBody
+    FcmTokenRequest request) {
+        userService.updateFcmToken(tokenClaim, request);
+        return ApiResponse.success(null);
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/global/firebase/dto/FcmTokenRequest.java
+++ b/src/main/java/com/sparta/spartatigers/global/firebase/dto/FcmTokenRequest.java
@@ -1,0 +1,5 @@
+package com.sparta.spartatigers.global.firebase.dto;
+
+public record FcmTokenRequest(
+    String fcmToken
+) {}

--- a/src/main/resources/db/migration/V8__add_fcmToken_to_user.sql
+++ b/src/main/resources/db/migration/V8__add_fcmToken_to_user.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN fcm_token VARCHAR(2048);


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 교환 요청 시 아이템 등록자에게 알림 전송
- 교환 요청 수락 시 신청자에게 알림 전송
- user에 fcmToken 추가
- 프론트에서 fcmToken을 받아올 수 있는 api 추가

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- close #42 

## 💬 기타 코멘트
- 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 푸시 알림 등록: 기기의 푸시 알림 토큰을 등록할 수 있습니다.
* 교환 요청 알림: 새로운 교환 요청이 들어올 때 실시간 알림을 받습니다.
* 교환 수락 알림: 본인의 교환 요청이 수락될 때 실시간 알림을 받습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->