### PR TITLE
[feat/oauth] 카카오 oauth 및 로그아웃 구현

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/auth/client/KakaoClient.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/client/KakaoClient.java
@@ -1,0 +1,78 @@
+package com.sparta.spartatigers.domain.auth.client;
+
+import com.sparta.spartatigers.domain.auth.dto.KakaoTokenResponse;
+import com.sparta.spartatigers.domain.auth.dto.KakaoUserInfo;
+import com.sparta.spartatigers.domain.auth.dto.KakaoUserMeResponse;
+import com.sparta.spartatigers.global.config.KakaoOauthProperties;
+import com.sparta.spartatigers.global.exception.enums.ExceptionCode;
+import com.sparta.spartatigers.global.exception.internal.InvalidRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoClient {
+
+    private final RestClient kakaoRestClient;
+    private final KakaoOauthProperties properties;
+
+    public String getAccessToken(String code, String redirectUri) {
+        try {
+            MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+            form.add("grant_type", "authorization_code");
+            form.add("client_id", properties.clientId());
+            form.add("redirect_uri", redirectUri);
+            form.add("code", code);
+
+            if (properties.clientSecret() != null && !properties.clientSecret().isBlank()) {
+                form.add("client_secret", properties.clientSecret());
+            }
+
+            KakaoTokenResponse res = kakaoRestClient.post()
+                .uri(properties.tokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .accept(MediaType.APPLICATION_JSON)
+                .body(form)
+                .retrieve()
+                .body(KakaoTokenResponse.class);
+
+            if (res == null || res.accessToken() == null || res.accessToken().isBlank()) {
+                throw new InvalidRequestException(ExceptionCode.OAUTH_TOKEN_EXCHANGE_FAILED);
+            }
+            return res.accessToken();
+
+        } catch (InvalidRequestException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Kakao token exchange failed: {}", e.getMessage(), e);
+            throw new InvalidRequestException(ExceptionCode.OAUTH_TOKEN_EXCHANGE_FAILED);
+        }
+    }
+
+    public KakaoUserInfo getUserInfo(String accessToken) {
+
+        KakaoUserMeResponse response = kakaoRestClient.get()
+            .uri(properties.userInfoUri())
+            .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+            .retrieve()
+            .body(KakaoUserMeResponse.class);
+
+        if (response == null || response.id() == null) {
+            throw new InvalidRequestException(ExceptionCode.OAUTH_USERINFO_FAILED);
+        }
+
+        return new KakaoUserInfo(
+            String.valueOf(response.id()),
+            response.kakaoAccount() != null ? response.kakaoAccount().email() : null,
+            response.properties() != null ? response.properties().nickname() : null,
+            response.properties() != null ? response.properties().profileImage() : null
+        );
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/controller/AuthController.java
@@ -23,28 +23,28 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/api/v1/auth/login")
+    @PostMapping("/api/auth/login")
     public ApiResponse<Token> login(@Valid @RequestBody UserLoginRequest request) {
         Token token = authService.login(request.email(), request.password());
 
         return ApiResponse.success(token);
     }
 
-    @PostMapping("/api/v1/auth/oauth/kakao")
+    @PostMapping("/api/auth/oauth/kakao")
     public ApiResponse<Token> kakaoLogin(@Valid @RequestBody OauthLoginRequest request) {
         Token token = authService.kakaoLogin(request.code(), request.redirectUri());
 
         return ApiResponse.success(token);
     }
 
-    @PostMapping("/api/v1/auth/logout")
+    @PostMapping("/api/auth/logout")
     public ApiResponse<Void> logout(@Valid @RequestBody LogoutRequest request) {
         authService.logout(request.refreshToken());
 
         return ApiResponse.success(null);
     }
 
-    @PostMapping("/api/v1/auth/refresh")
+    @PostMapping("/api/auth/refresh")
     public ApiResponse<Token> refresh(@Valid @RequestBody RefreshRequest request) {
         Token token = authService.refresh(request.refreshToken());
 

--- a/src/main/java/com/sparta/spartatigers/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.sparta.spartatigers.domain.auth.controller;
 
+import com.sparta.spartatigers.domain.auth.dto.OauthLoginRequest;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,6 +24,13 @@ public class AuthController {
     @PostMapping("/api/v1/auth/login")
     public ApiResponse<Token> login(@Valid @RequestBody UserLoginRequest request) {
         Token token = authService.login(request.email(), request.password());
+
+        return ApiResponse.success(token);
+    }
+
+    @PostMapping("/api/v1/auth/oauth/kakao")
+    public ApiResponse<Token> kakaoLogin(@Valid @RequestBody OauthLoginRequest request) {
+        Token token = authService.kakaoLogin(request.code(), request.redirectUri());
 
         return ApiResponse.success(token);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/controller/AuthController.java
@@ -1,6 +1,8 @@
 package com.sparta.spartatigers.domain.auth.controller;
 
+import com.sparta.spartatigers.domain.auth.dto.LogoutRequest;
 import com.sparta.spartatigers.domain.auth.dto.OauthLoginRequest;
+import com.sparta.spartatigers.domain.auth.dto.RefreshRequest;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,6 +33,20 @@ public class AuthController {
     @PostMapping("/api/v1/auth/oauth/kakao")
     public ApiResponse<Token> kakaoLogin(@Valid @RequestBody OauthLoginRequest request) {
         Token token = authService.kakaoLogin(request.code(), request.redirectUri());
+
+        return ApiResponse.success(token);
+    }
+
+    @PostMapping("/api/v1/auth/logout")
+    public ApiResponse<Void> logout(@Valid @RequestBody LogoutRequest request) {
+        authService.logout(request.refreshToken());
+
+        return ApiResponse.success(null);
+    }
+
+    @PostMapping("/api/v1/auth/refresh")
+    public ApiResponse<Token> refresh(@Valid @RequestBody RefreshRequest request) {
+        Token token = authService.refresh(request.refreshToken());
 
         return ApiResponse.success(token);
     }

--- a/src/main/java/com/sparta/spartatigers/domain/auth/dto/KakaoTokenResponse.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/dto/KakaoTokenResponse.java
@@ -1,0 +1,14 @@
+package com.sparta.spartatigers.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record KakaoTokenResponse(
+    @JsonProperty("access_token") String accessToken,
+    @JsonProperty("token_type") String tokenType,
+    @JsonProperty("refresh_token") String refreshToken,
+    @JsonProperty("expires_in") Integer expiresIn,
+    @JsonProperty("refresh_token_expires_in") Integer refreshTokenExpiresIn,
+    String scope
+) {
+
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/dto/KakaoUserInfo.java
@@ -1,0 +1,10 @@
+package com.sparta.spartatigers.domain.auth.dto;
+
+public record KakaoUserInfo(
+    String id,
+    String email,
+    String nickname,
+    String profileImageUrl
+) {
+
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/dto/KakaoUserMeResponse.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/dto/KakaoUserMeResponse.java
@@ -1,0 +1,24 @@
+package com.sparta.spartatigers.domain.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserMeResponse(
+    Long id,
+    Properties properties,
+    @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Properties(
+        String nickname,
+        @JsonProperty("profile_image") String profileImage,
+        @JsonProperty("thumbnail_image") String thumbnailImage
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KakaoAccount(
+        String email
+    ) {}
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/dto/LogoutRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.spartatigers.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(
+    @NotBlank String refreshToken
+    ) {
+
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/dto/OauthLoginRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/dto/OauthLoginRequest.java
@@ -1,0 +1,10 @@
+package com.sparta.spartatigers.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record OauthLoginRequest(
+    @NotBlank String code,
+    @NotBlank String redirectUri
+) {
+
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/dto/RefreshRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/dto/RefreshRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.spartatigers.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(
+    @NotBlank String refreshToken
+) {
+
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/model/RefreshToken.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/model/RefreshToken.java
@@ -1,0 +1,27 @@
+package com.sparta.spartatigers.domain.auth.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Getter
+@RedisHash("refreshToken")
+public class RefreshToken {
+
+    @Id
+    private String token;
+
+    private String subject;
+
+    @TimeToLive
+    private long ttlSeconds;
+
+    @Builder
+    public RefreshToken(String token, String subject, long ttlSeconds) {
+        this.token = token;
+        this.subject = subject;
+        this.ttlSeconds = ttlSeconds;
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/repository/OauthRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/repository/OauthRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.spartatigers.domain.auth.repository;
+
+import com.sparta.spartatigers.domain.auth.model.OAuthProvider;
+import com.sparta.spartatigers.domain.auth.model.Oauth;
+import com.sparta.spartatigers.domain.user.model.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OauthRepository extends JpaRepository<Oauth, Long> {
+
+    Optional<Oauth> findByProviderAndProviderId(OAuthProvider provider, String providerId);
+    boolean existsByUserAndProvider(User user, OAuthProvider provider);
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.spartatigers.domain.auth.repository;
+
+import com.sparta.spartatigers.domain.auth.model.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+}

--- a/src/main/java/com/sparta/spartatigers/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/service/AuthService.java
@@ -1,5 +1,12 @@
 package com.sparta.spartatigers.domain.auth.service;
 
+import com.sparta.spartatigers.domain.auth.client.KakaoClient;
+import com.sparta.spartatigers.domain.auth.dto.KakaoUserInfo;
+import com.sparta.spartatigers.domain.auth.model.OAuthProvider;
+import com.sparta.spartatigers.domain.auth.model.Oauth;
+import com.sparta.spartatigers.domain.auth.repository.OauthRepository;
+import com.sparta.spartatigers.domain.user.model.UserRole;
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 import com.sparta.spartatigers.domain.auth.model.Token;
@@ -10,6 +17,7 @@ import com.sparta.spartatigers.global.exception.enums.ExceptionCode;
 import com.sparta.spartatigers.global.exception.internal.InvalidRequestException;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +25,8 @@ public class AuthService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final OauthRepository oauthRepository;
+    private final KakaoClient kakaoClient;
     private final TokenService tokenService;
 
     public Token login(final String email, final String password) {
@@ -32,5 +42,68 @@ public class AuthService {
 
         TokenClaim tokenClaim = TokenClaim.from(user);
         return tokenService.generateToken(tokenClaim);
+    }
+
+    @Transactional
+    public Token kakaoLogin(String code, String redirectUri) {
+
+        String accessToken = kakaoClient.getAccessToken(code, redirectUri);
+
+        KakaoUserInfo info = kakaoClient.getUserInfo(accessToken);
+
+        if (info.email() == null || info.email().isBlank()) {
+            throw new InvalidRequestException(ExceptionCode.OAUTH_EMAIL_REQUIRED);
+        }
+
+        User user = oauthRepository
+            .findByProviderAndProviderId(OAuthProvider.KAKAO, info.id())
+            .map(Oauth::getUser)
+            .orElseGet(() -> findOrCreateKakaoUser(info));
+
+        TokenClaim tokenClaim = TokenClaim.from(user);
+        return tokenService.generateToken(tokenClaim);
+    }
+
+    private User findOrCreateKakaoUser(KakaoUserInfo info) {
+        return userRepository.findByEmail(info.email())
+            .map(existingUser -> {
+                if (!oauthRepository.existsByUserAndProvider(existingUser, OAuthProvider.KAKAO)) {
+                    oauthRepository.save(
+                        Oauth.builder()
+                            .provider(OAuthProvider.KAKAO)
+                            .providerId(info.id())
+                            .user(existingUser)
+                            .build()
+                    );
+                }
+                return existingUser;
+            })
+            .orElseGet(() -> createKakaoUser(info));
+    }
+
+    private User createKakaoUser(KakaoUserInfo info) {
+
+        String randomPassword = UUID.randomUUID().toString();
+        String encodedPassword = passwordEncoder.hash(randomPassword);
+
+        User user = userRepository.save(
+            User.builder()
+                .email(info.email())
+                .password(encodedPassword)
+                .nickname(info.nickname())
+                .profileImageUrl(info.profileImageUrl())
+                .role(UserRole.ROLE_USER)
+                .build()
+        );
+
+        oauthRepository.save(
+            Oauth.builder()
+                .provider(OAuthProvider.KAKAO)
+                .providerId(info.id())
+                .user(user)
+                .build()
+        );
+
+        return user;
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/auth/service/AuthService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/service/AuthService.java
@@ -4,7 +4,9 @@ import com.sparta.spartatigers.domain.auth.client.KakaoClient;
 import com.sparta.spartatigers.domain.auth.dto.KakaoUserInfo;
 import com.sparta.spartatigers.domain.auth.model.OAuthProvider;
 import com.sparta.spartatigers.domain.auth.model.Oauth;
+import com.sparta.spartatigers.domain.auth.model.RefreshToken;
 import com.sparta.spartatigers.domain.auth.repository.OauthRepository;
+import com.sparta.spartatigers.domain.auth.repository.RefreshTokenRepository;
 import com.sparta.spartatigers.domain.user.model.UserRole;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ import com.sparta.spartatigers.global.exception.internal.InvalidRequestException
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +31,7 @@ public class AuthService {
     private final OauthRepository oauthRepository;
     private final KakaoClient kakaoClient;
     private final TokenService tokenService;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public Token login(final String email, final String password) {
         User user = userRepository
@@ -59,6 +63,44 @@ public class AuthService {
             .findByProviderAndProviderId(OAuthProvider.KAKAO, info.id())
             .map(Oauth::getUser)
             .orElseGet(() -> findOrCreateKakaoUser(info));
+
+        TokenClaim tokenClaim = TokenClaim.from(user);
+        return tokenService.generateToken(tokenClaim);
+    }
+
+    @Transactional
+    public void logout(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new InvalidRequestException(ExceptionCode.INVALID_REFRESH_TOKEN);
+        }
+
+        refreshTokenRepository.deleteById(refreshToken);
+    }
+
+    @Transactional
+    public Token refresh(String refreshToken) {
+        if (!StringUtils.hasText(refreshToken)) {
+            throw new InvalidRequestException(ExceptionCode.INVALID_REFRESH_TOKEN);
+        }
+
+        TokenClaim refreshClaim = tokenService.parseRefreshToken(refreshToken);
+        String subject = refreshClaim.getSubject();
+
+        if (!StringUtils.hasText(subject)) {
+            throw new InvalidRequestException(ExceptionCode.INVALID_REFRESH_TOKEN);
+        }
+
+        RefreshToken saved = refreshTokenRepository.findById(refreshToken)
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.INVALID_REFRESH_TOKEN));
+
+        if (saved.getSubject()==null || !saved.getSubject().equals(subject)) {
+            throw new InvalidRequestException(ExceptionCode.INVALID_REFRESH_TOKEN);
+        }
+
+        User user = userRepository.findByEmail(subject)
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.USER_NOT_FOUND));
+
+        refreshTokenRepository.deleteById(refreshToken);
 
         TokenClaim tokenClaim = TokenClaim.from(user);
         return tokenService.generateToken(tokenClaim);

--- a/src/main/java/com/sparta/spartatigers/domain/auth/service/JwtTokenService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/auth/service/JwtTokenService.java
@@ -1,7 +1,10 @@
 package com.sparta.spartatigers.domain.auth.service;
 
+import com.sparta.spartatigers.domain.auth.model.RefreshToken;
+import com.sparta.spartatigers.domain.auth.repository.RefreshTokenRepository;
 import java.util.Date;
 
+import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
 
 import org.springframework.stereotype.Service;
@@ -24,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtTokenService implements TokenService {
 
     private final JwtConfig jwtConfig;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Override
     public Token generateToken(TokenClaim tokenClaim) {
@@ -38,32 +42,43 @@ public class JwtTokenService implements TokenService {
         Date nowDate = new Date(now);
 
         final String accessToken = Jwts.builder()
-                .subject(tokenClaim.getSubject())
-                .claim("userId", tokenClaim.getUserId())
-                .claim("email", tokenClaim.getEmail())
-                .claim("nickname", tokenClaim.getNickname())
-                .claim("profileImageUrl", tokenClaim.getProfileImageUrl())
-                .claim("role", tokenClaim.getRole())
-                .issuedAt(nowDate)
-                .expiration(accessTokenExpireAt)
-                .signWith(accessTokenSecretKey)
-                .compact();
+            .subject(tokenClaim.getSubject())
+            .claim("userId", tokenClaim.getUserId())
+            .claim("email", tokenClaim.getEmail())
+            .claim("nickname", tokenClaim.getNickname())
+            .claim("profileImageUrl", tokenClaim.getProfileImageUrl())
+            .claim("role", tokenClaim.getRole())
+            .issuedAt(nowDate)
+            .expiration(accessTokenExpireAt)
+            .signWith(accessTokenSecretKey)
+            .compact();
 
         final String refreshToken = Jwts.builder()
+            .subject(tokenClaim.getSubject())
+            .issuedAt(nowDate)
+            .expiration(refreshTokenExpireAt)
+            .signWith(refreshTokenSecret)
+            .compact();
+
+        long ttlSeconds = TimeUnit.MILLISECONDS.toSeconds(jwtConfig.getRefreshToken().expire());
+        log.info("refresh expire raw={}, ttlSeconds={}",
+            jwtConfig.getRefreshToken().expire(), ttlSeconds);
+        refreshTokenRepository.save(
+            RefreshToken.builder()
+                .token(refreshToken)
                 .subject(tokenClaim.getSubject())
-                .issuedAt(nowDate)
-                .expiration(refreshTokenExpireAt)
-                .signWith(refreshTokenSecret)
-                .compact();
+                .ttlSeconds(ttlSeconds)
+                .build()
+        );
 
         return Token.builder()
-                .accessToken(accessToken)
-                .accessTokenExpiredAt(accessTokenExpireAt)
-                .accessTokenIssuedAt(nowDate)
-                .refreshToken(refreshToken)
-                .refreshTokenExpiredAt(refreshTokenExpireAt)
-                .refreshTokenIssuedAt(nowDate)
-                .build();
+            .accessToken(accessToken)
+            .accessTokenExpiredAt(accessTokenExpireAt)
+            .accessTokenIssuedAt(nowDate)
+            .refreshToken(refreshToken)
+            .refreshTokenExpiredAt(refreshTokenExpireAt)
+            .refreshTokenIssuedAt(nowDate)
+            .build();
     }
 
     @Override
@@ -79,13 +94,13 @@ public class JwtTokenService implements TokenService {
         final String userRole = claimsJws.getPayload().get("role", String.class);
 
         return TokenClaim.builder()
-                .subject(email)
-                .userId(userId.longValue())
-                .email(email)
-                .nickname(nickname)
-                .profileImageUrl(profileImageUrl)
-                .role(UserRole.from(userRole))
-                .build();
+            .subject(email)
+            .userId(userId.longValue())
+            .email(email)
+            .nickname(nickname)
+            .profileImageUrl(profileImageUrl)
+            .role(UserRole.from(userRole))
+            .build();
     }
 
     @Override
@@ -96,8 +111,8 @@ public class JwtTokenService implements TokenService {
         final String subject = claimsJws.getPayload().getSubject();
 
         return TokenClaim.builder()
-                .subject(subject)
-                .build();
+            .subject(subject)
+            .build();
     }
 
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/exchanges")
+@RequestMapping("/api/exchanges")
 public class ExchangeRequestController {
 
     private final ExchangeRequestService exchangeRequestService;

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/request/ExchangeRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/request/ExchangeRequestDto.java
@@ -1,10 +1,12 @@
 package com.sparta.spartatigers.domain.exchangerequest.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ExchangeRequestDto(
     @NotNull(message = "요청 받을 사람의 아이디는 필수입니다.") Long receiverId,
-    @NotNull(message = "교환하고 싶은 아이템 아이디 입력은 필수입니다.") Long itemId
-) {
+    @NotNull(message = "교환하고 싶은 아이템 아이디 입력은 필수입니다.") Long itemId,
+    @NotBlank(message = "교환할 아이템 입력은 필수입니다.") String have
+    ) {
 
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/ExchangeRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/model/ExchangeRequest.java
@@ -47,16 +47,19 @@ public class ExchangeRequest extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ExchangeStatus status;
 
-    public ExchangeRequest(Item item, User sender, User receiver, ExchangeStatus exchangeStatus) {
+    private String have;
+
+    public ExchangeRequest(Item item, User sender, User receiver, ExchangeStatus exchangeStatus, String have) {
         this.item = item;
         this.sender = sender;
         this.receiver = receiver;
         this.status = exchangeStatus;
+        this.have = have;
     }
 
-    public static ExchangeRequest of(Item item, User sender, User receiver) {
+    public static ExchangeRequest of(Item item, User sender, User receiver, String have) {
 
-        return new ExchangeRequest(item, sender, receiver, ExchangeStatus.PENDING);
+        return new ExchangeRequest(item, sender, receiver, ExchangeStatus.PENDING, have);
     }
 
     public void validateReceiverIsOwner(User receiver) {

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -46,7 +46,9 @@ public class ExchangeRequestService {
 
         checkDuplicateExchangeRequest(sender.getId(), receiver.getId(), item.getId());
 
-        ExchangeRequest exchangeRequest = ExchangeRequest.of(item, sender, receiver);
+        String have = request.have();
+
+        ExchangeRequest exchangeRequest = ExchangeRequest.of(item, sender, receiver, have);
         exchangeRequestRepository.save(exchangeRequest);
     }
 

--- a/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/items")
+@RequestMapping("/api/items")
 public class ItemController {
 
     private final ItemService itemService;

--- a/src/main/java/com/sparta/spartatigers/global/config/KakaoOauthProperties.java
+++ b/src/main/java/com/sparta/spartatigers/global/config/KakaoOauthProperties.java
@@ -1,0 +1,13 @@
+package com.sparta.spartatigers.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "oauth.kakao")
+public record KakaoOauthProperties(
+     String clientId,
+     String clientSecret,
+     String tokenUri,
+     String userInfoUri
+) {
+
+}

--- a/src/main/java/com/sparta/spartatigers/global/config/OauthConfig.java
+++ b/src/main/java/com/sparta/spartatigers/global/config/OauthConfig.java
@@ -1,0 +1,16 @@
+package com.sparta.spartatigers.global.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+@EnableConfigurationProperties(KakaoOauthProperties.class)
+public class OauthConfig {
+
+    @Bean
+    public RestClient kakaoRestClient(RestClient.Builder builder) {
+        return builder.build();
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/global/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/enums/ExceptionCode.java
@@ -29,6 +29,9 @@ public enum ExceptionCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, ErrorCode.E403, "해당 계정의 접근 권한이 없습니다.", LogLevel.DEBUG),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, ErrorCode.E400, "현재 비밀번호가 일치하지 않습니다.", LogLevel.DEBUG),
     SAME_AS_OLD_PASSWORD(HttpStatus.BAD_REQUEST, ErrorCode.E400, "새 비밀번호는 현재 비밀번호와 달라야 합니다.", LogLevel.DEBUG),
+    OAUTH_TOKEN_EXCHANGE_FAILED(HttpStatus.BAD_REQUEST, ErrorCode.E400, "카카오 로그인에 실패했습니다.", LogLevel.DEBUG),
+    OAUTH_USERINFO_FAILED(HttpStatus.BAD_REQUEST, ErrorCode.E400, "카카오 사용자 정보를 가져오지 못했습니다.", LogLevel.DEBUG),
+    OAUTH_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, ErrorCode.E400, "카카오 로그인 시 이메일 제공 동의가 필요합니다.", LogLevel.DEBUG),
 
     // 파일
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "파일 업로드에 실패했습니다.", LogLevel.ERROR),

--- a/src/main/java/com/sparta/spartatigers/global/exception/enums/ExceptionCode.java
+++ b/src/main/java/com/sparta/spartatigers/global/exception/enums/ExceptionCode.java
@@ -19,6 +19,7 @@ public enum ExceptionCode {
     NOT_SUPPORTED_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, ErrorCode.E400, "지원하지 않는 소셜 로그인입니다.", LogLevel.DEBUG),
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, ErrorCode.E401, "인증된 사용자만 수행할 수 있는 요청입니다.", LogLevel.DEBUG),
     AUTHORIZATION_ERROR(HttpStatus.FORBIDDEN, ErrorCode.E403, "권한이 부족한 유저입니다.", LogLevel.DEBUG),
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, ErrorCode.E400, "유효하지 않은 리프레시 토큰입니다.", LogLevel.DEBUG),
 
     // 회원
     EMAIL_ALREADY_USED(HttpStatus.BAD_REQUEST, ErrorCode.E400, "이미 사용 중인 이메일입니다.", LogLevel.DEBUG),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -85,3 +85,13 @@ weather:
   api:
     key: ${WEATHER_API_KEY}
 
+# ===============================
+# OAuth Settings
+# ===============================
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    client-secret: ${KAKAO_CLIENT_SECRET}
+    redirect-uri: http://localhost:8080/oauth/callback
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me

--- a/src/main/resources/db/migration/V13__add_have_column_to_exchangerequest.sql
+++ b/src/main/resources/db/migration/V13__add_have_column_to_exchangerequest.sql
@@ -1,0 +1,2 @@
+ALTER TABLE exchange_request
+    ADD COLUMN have VARCHAR(1000) NOT NULL;


### PR DESCRIPTION
## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 카카오 oauth를 이용한 소셜 로그인 구현
- 로그아웃 엔드포인트 구현
- 로그인/로그아웃/아이템/교환 요청 API 엔드포인트에 v1 제거
- 교환 요청 시 사용자가 교환할 물건을 입력하도록 have 컬럼 추가

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- close #48 

## 💬 기타 코멘트
- 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Kakao 소셜 로그인 기능 추가
  * 토큰 갱신 기능 추가
  * 로그아웃 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->