### PR TITLE
[feat/exchange] 교환/아이템 위치 연동 및 디바이스 토큰 API 정리

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/directRoom/controller/DirectRoomController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/directRoom/controller/DirectRoomController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.sparta.spartatigers.domain.auth.model.TokenClaim;
 import com.sparta.spartatigers.domain.directRoom.dto.request.CreateDirectRoomRequestDto;
 import com.sparta.spartatigers.domain.directRoom.dto.response.DirectRoomCreateResponseDto;
+import com.sparta.spartatigers.domain.directRoom.dto.response.DirectRoomItemResponseDto;
 import com.sparta.spartatigers.domain.directRoom.dto.response.DirectRoomResponseDto;
 import com.sparta.spartatigers.domain.directRoom.service.DirectRoomService;
 import com.sparta.spartatigers.global.aop.Auth;
@@ -48,6 +49,15 @@ public class DirectRoomController {
         Page<DirectRoomResponseDto> rooms =
             directRoomService.getRoomsForUser(currentUserId, pageable);
         return ApiResponse.success(rooms);
+    }
+
+    @GetMapping("/{directRoomId}/item")
+    public ApiResponse<DirectRoomItemResponseDto> getDirectRoomItem(
+        @PathVariable Long directRoomId,
+        @Auth TokenClaim tokenClaim) {
+        Long currentUserId = tokenClaim.getUserId();
+        DirectRoomItemResponseDto response = directRoomService.getRoomItem(directRoomId, currentUserId);
+        return ApiResponse.success(response);
     }
 
     @DeleteMapping("/{directRoomId}")

--- a/src/main/java/com/sparta/spartatigers/domain/directRoom/dto/response/DirectRoomItemResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/directRoom/dto/response/DirectRoomItemResponseDto.java
@@ -1,0 +1,32 @@
+package com.sparta.spartatigers.domain.directRoom.dto.response;
+
+import com.sparta.spartatigers.domain.item.model.Item;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class DirectRoomItemResponseDto {
+
+    private Long itemId;
+    private String title;
+    private String description;
+    private String category;
+    private String status;
+    private Long ownerId;
+    private String ownerNickname;
+
+    public static DirectRoomItemResponseDto from(Item item) {
+        return new DirectRoomItemResponseDto(
+            item.getId(),
+            item.getTitle(),
+            item.getDescription(),
+            item.getCategory().name(),
+            item.getStatus().name(),
+            item.getUser().getId(),
+            item.getUser().getNickname());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/directRoom/service/DirectRoomService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/directRoom/service/DirectRoomService.java
@@ -6,12 +6,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sparta.spartatigers.domain.directRoom.dto.response.DirectRoomCreateResponseDto;
+import com.sparta.spartatigers.domain.directRoom.dto.response.DirectRoomItemResponseDto;
 import com.sparta.spartatigers.domain.directRoom.dto.response.DirectRoomResponseDto;
 import com.sparta.spartatigers.domain.directRoom.model.DirectRoom;
 import com.sparta.spartatigers.domain.directRoom.repository.DirectMessageRepository;
 import com.sparta.spartatigers.domain.directRoom.repository.DirectRoomRepository;
 import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeRequest;
 import com.sparta.spartatigers.domain.exchangerequest.repository.ExchangeRequestRepository;
+import com.sparta.spartatigers.domain.item.model.Item;
 import com.sparta.spartatigers.domain.user.model.User;
 import com.sparta.spartatigers.global.exception.enums.ExceptionCode;
 import com.sparta.spartatigers.global.exception.internal.InvalidRequestException;
@@ -89,6 +91,25 @@ public class DirectRoomService {
 
                     return DirectRoomResponseDto.from(room, unreadCount, currentUserId, isOnline);
                 });
+    }
+
+    @Transactional(readOnly = true)
+    public DirectRoomItemResponseDto getRoomItem(Long directRoomId, Long currentUserId) {
+        DirectRoom room =
+            directRoomRepository
+                .findById(directRoomId)
+                .orElseThrow(() -> new InvalidRequestException(ExceptionCode.CHATROOM_NOT_FOUND));
+
+        boolean isSender = room.getSender().getId().equals(currentUserId);
+        boolean isReceiver = room.getReceiver().getId().equals(currentUserId);
+        if (!isSender && !isReceiver) {
+            throw new InvalidRequestException(ExceptionCode.FORBIDDEN_REQUEST);
+        }
+
+        ExchangeRequest exchangeRequest = room.getExchangeRequest();
+        Item item = exchangeRequest.getItem();
+
+        return DirectRoomItemResponseDto.from(item);
     }
 
     // 유저가 직접 채팅방을 삭제할 수도 있음

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/controller/ExchangeRequestController.java
@@ -10,12 +10,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.sparta.spartatigers.domain.auth.model.TokenClaim;
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.UpdateExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.ExchangeRoomResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
+import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeStatus;
 import com.sparta.spartatigers.domain.exchangerequest.service.ExchangeRequestService;
 import com.sparta.spartatigers.global.aop.Auth;
 import com.sparta.spartatigers.global.response.ApiResponse;
@@ -31,12 +34,11 @@ public class ExchangeRequestController {
     private final ExchangeRequestService exchangeRequestService;
 
     @PostMapping
-    public ApiResponse<?> createExchangeRequest(@Valid @RequestBody ExchangeRequestDto request,
+    public ApiResponse<ExchangeRoomResponseDto> createExchangeRequest(@Valid @RequestBody ExchangeRequestDto request,
         @Auth TokenClaim tokenClaim) {
 
-        exchangeRequestService.createExchangeRequest(request, tokenClaim);
-
-        return ApiResponse.success(null);
+        Long exchangeRequestId = exchangeRequestService.createExchangeRequest(request, tokenClaim);
+        return ApiResponse.success(ExchangeRoomResponseDto.created(exchangeRequestId));
     }
 
     @GetMapping("/receive")
@@ -51,12 +53,11 @@ public class ExchangeRequestController {
     }
 
     @PatchMapping("/{exchangeRequestId}")
-    public ApiResponse<?> updateRequestStatus(@PathVariable Long exchangeRequestId,
+    public ApiResponse<ExchangeRoomResponseDto> updateRequestStatus(@PathVariable Long exchangeRequestId,
         @Valid @RequestBody UpdateExchangeRequestDto request, @Auth TokenClaim tokenClaim) {
 
-        exchangeRequestService.updateRequestStatus(exchangeRequestId, request, tokenClaim);
-
-        return ApiResponse.success(null);
+        ExchangeRoomResponseDto response = exchangeRequestService.updateRequestStatus(exchangeRequestId, request, tokenClaim);
+        return ApiResponse.success(response);
     }
 
     @PatchMapping("/{exchangeRequestId}/complete")
@@ -66,5 +67,18 @@ public class ExchangeRequestController {
         exchangeRequestService.completeExchange(exchangeRequestId, tokenClaim);
 
         return ApiResponse.success(null);
+    }
+
+    @GetMapping("/my")
+    public ApiResponse<Page<ReceiveRequestResponseDto>> findMyExchangeRequests(
+        @RequestParam String role,
+        @RequestParam(required = false) ExchangeStatus status,
+        @Auth TokenClaim tokenClaim,
+        @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+
+        Page<ReceiveRequestResponseDto> response = exchangeRequestService.findMyExchangeRequests(
+            role, status, pageable, tokenClaim);
+
+        return ApiResponse.success(response);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ExchangeRoomResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/dto/response/ExchangeRoomResponseDto.java
@@ -1,0 +1,24 @@
+package com.sparta.spartatigers.domain.exchangerequest.dto.response;
+
+import com.sparta.spartatigers.domain.directRoom.dto.response.DirectRoomCreateResponseDto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ExchangeRoomResponseDto {
+
+    private Long directRoomId;
+    private Long exchangeRequestId;
+
+    public static ExchangeRoomResponseDto created(Long exchangeRequestId) {
+        return new ExchangeRoomResponseDto(null, exchangeRequestId);
+    }
+
+    public static ExchangeRoomResponseDto from(DirectRoomCreateResponseDto directRoom) {
+        return new ExchangeRoomResponseDto(directRoom.getDirectRoomId(), directRoom.getExchangeRequestId());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/repository/ExchangeRequestRepository.java
@@ -22,6 +22,18 @@ public interface ExchangeRequestRepository extends JpaRepository<ExchangeRequest
     @Query("select e from exchange_request e where e.receiver.id = :receiverId")
     Page<ExchangeRequest> findAllReceiveRequest(@Param("receiverId") Long receiverId, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"receiver", "sender", "item"})
+    @Query("select e from exchange_request e where e.sender.id = :senderId")
+    Page<ExchangeRequest> findAllSentRequest(@Param("senderId") Long senderId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"receiver", "sender", "item"})
+    @Query("select e from exchange_request e where e.sender.id = :senderId and e.status = :status")
+    Page<ExchangeRequest> findAllSentRequestWithStatus(@Param("senderId") Long senderId, @Param("status") ExchangeStatus status, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"receiver", "sender", "item"})
+    @Query("select e from exchange_request e where e.receiver.id = :receiverId and e.status = :status")
+    Page<ExchangeRequest> findAllReceiveRequestWithStatus(@Param("receiverId") Long receiverId, @Param("status") ExchangeStatus status, Pageable pageable);
+
     Optional<ExchangeRequest> findByIdAndStatus(
         Long exchangeRequestId, ExchangeStatus status);
 

--- a/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/exchangerequest/service/ExchangeRequestService.java
@@ -1,14 +1,20 @@
 package com.sparta.spartatigers.domain.exchangerequest.service;
 
+import java.util.Map;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.sparta.spartatigers.domain.auth.model.TokenClaim;
+import com.sparta.spartatigers.domain.directRoom.dto.response.DirectRoomCreateResponseDto;
+import com.sparta.spartatigers.domain.directRoom.model.DirectRoom;
+import com.sparta.spartatigers.domain.directRoom.repository.DirectRoomRepository;
 import com.sparta.spartatigers.domain.directRoom.service.DirectRoomService;
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.ExchangeRequestDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.request.UpdateExchangeRequestDto;
+import com.sparta.spartatigers.domain.exchangerequest.dto.response.ExchangeRoomResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.dto.response.ReceiveRequestResponseDto;
 import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeRequest;
 import com.sparta.spartatigers.domain.exchangerequest.model.ExchangeStatus;
@@ -18,7 +24,6 @@ import com.sparta.spartatigers.domain.item.repository.ItemRepository;
 import com.sparta.spartatigers.domain.stompchat.service.LocationService;
 import com.sparta.spartatigers.domain.user.model.User;
 import com.sparta.spartatigers.domain.user.repository.UserRepository;
-import java.util.Map;
 import com.sparta.spartatigers.global.exception.enums.ExceptionCode;
 import com.sparta.spartatigers.global.exception.internal.InvalidRequestException;
 
@@ -30,12 +35,13 @@ public class ExchangeRequestService {
 
     private final ExchangeRequestRepository exchangeRequestRepository;
     private final DirectRoomService directRoomService;
+    private final DirectRoomRepository directRoomRepository;
     private final UserRepository userRepository;
     private final LocationService locationService;
     private final ItemRepository itemRepository;
 
     @Transactional
-    public void createExchangeRequest(ExchangeRequestDto request, TokenClaim tokenClaim) {
+    public Long createExchangeRequest(ExchangeRequestDto request, TokenClaim tokenClaim) {
 
         User sender = getUser(tokenClaim.getUserId());
         User receiver = getUser(request.receiverId());
@@ -49,7 +55,8 @@ public class ExchangeRequestService {
         String have = request.have();
 
         ExchangeRequest exchangeRequest = ExchangeRequest.of(item, sender, receiver, have);
-        exchangeRequestRepository.save(exchangeRequest);
+        ExchangeRequest saved = exchangeRequestRepository.save(exchangeRequest);
+        return saved.getId();
     }
 
     public Page<ReceiveRequestResponseDto> findAllReceiveRequest(TokenClaim tokenClaim, Pageable pageable) {
@@ -62,7 +69,7 @@ public class ExchangeRequestService {
     }
 
     @Transactional
-    public void updateRequestStatus(Long exchangeRequestId, UpdateExchangeRequestDto request,
+    public ExchangeRoomResponseDto updateRequestStatus(Long exchangeRequestId, UpdateExchangeRequestDto request,
         TokenClaim tokenClaim) {
 
         User user = getUser(tokenClaim.getUserId());
@@ -72,12 +79,15 @@ public class ExchangeRequestService {
         exchangeRequest.updateStatus(request.status());
 
         if (exchangeRequest.getStatus() == ExchangeStatus.ACCEPTED) {
-            directRoomService.createRoom(exchangeRequestId, user.getId());
+            DirectRoomCreateResponseDto room = directRoomService.createRoom(exchangeRequestId, user.getId());
+            return ExchangeRoomResponseDto.from(room);
         }
 
         if (exchangeRequest.getStatus() == ExchangeStatus.REJECTED) {
             exchangeRequestRepository.delete(exchangeRequest);
         }
+
+        return null;
     }
 
     @Transactional
@@ -94,8 +104,36 @@ public class ExchangeRequestService {
 
         exchangeRequest.complete();
 
+        directRoomRepository
+            .findByExchangeRequestId(exchangeRequestId)
+            .ifPresent(DirectRoom::complete);
+
         Map<String, Object> data = Map.of("itemId", item.getId(), "userId", item.getUser().getId());
         locationService.notifyUsersNearBy(item.getUser().getId(), "REMOVE_ITEM", data);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ReceiveRequestResponseDto> findMyExchangeRequests(String role, ExchangeStatus status, Pageable pageable, TokenClaim tokenClaim) {
+        Long userId = tokenClaim.getUserId();
+        Page<ExchangeRequest> requests;
+
+        if ("sender".equals(role)) {
+            if (status == null) {
+                requests = exchangeRequestRepository.findAllSentRequest(userId, pageable);
+            } else {
+                requests = exchangeRequestRepository.findAllSentRequestWithStatus(userId, status, pageable);
+            }
+        } else if ("receiver".equals(role)) {
+            if (status == null) {
+                requests = exchangeRequestRepository.findAllReceiveRequest(userId, pageable);
+            } else {
+                requests = exchangeRequestRepository.findAllReceiveRequestWithStatus(userId, status, pageable);
+            }
+        } else {
+            throw new InvalidRequestException(ExceptionCode.VALIDATION_ERROR);
+        }
+
+        return requests.map(ReceiveRequestResponseDto::from);
     }
 
     private User getUser(Long userId) {

--- a/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/controller/ItemController.java
@@ -23,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.sparta.spartatigers.domain.auth.model.TokenClaim;
 import com.sparta.spartatigers.domain.image.service.ImageStorageService;
 import com.sparta.spartatigers.domain.item.dto.request.ItemCreateRequest;
+import com.sparta.spartatigers.domain.item.dto.request.UpdateItemStatusRequestDto;
 import com.sparta.spartatigers.domain.item.dto.request.UpdateItemRequestDto;
 import com.sparta.spartatigers.domain.item.dto.response.ItemResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemDetailResponseDto;
@@ -86,6 +87,14 @@ public class ItemController {
         return ApiResponse.success(response);
     }
 
+    @GetMapping("/my")
+    public ApiResponse<Page<ReadItemResponseDto>> findMyItems(
+        @Auth TokenClaim tokenClaim,
+        @PageableDefault(sort = "createdAt", direction = Direction.DESC) Pageable pageable) {
+        Page<ReadItemResponseDto> response = itemService.findMyItems(tokenClaim, pageable);
+        return ApiResponse.success(response);
+    }
+
     @GetMapping("/{itemId}")
     public ApiResponse<ReadItemDetailResponseDto> findItemById(@PathVariable Long itemId) {
 
@@ -109,5 +118,14 @@ public class ItemController {
         ItemResponseDto response = itemService.updateItem(tokenClaim, itemId, request);
 
         return ApiResponse.success(response);
+    }
+
+    @PatchMapping("/{itemId}/status")
+    public ApiResponse<Void> updateItemStatus(
+        @Auth TokenClaim tokenClaim,
+        @PathVariable Long itemId,
+        @Valid @RequestBody UpdateItemStatusRequestDto request) {
+        itemService.updateItemStatus(tokenClaim, itemId, request);
+        return ApiResponse.success(null);
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/request/ItemCreateRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/request/ItemCreateRequest.java
@@ -1,6 +1,7 @@
 package com.sparta.spartatigers.domain.item.dto.request;
 
 import com.sparta.spartatigers.domain.item.model.ItemCategory;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -8,5 +9,14 @@ public record ItemCreateRequest(
     @NotNull(message = "카테고리는 필수입니다.") ItemCategory category,
     @NotBlank(message = "제목은 필수입니다.") String title,
     String seatInfo,
-    String description
-) {}
+    String description,
+    Location location
+) {
+
+    public record Location(
+        Double latitude,
+        Double longitude,
+        String address
+    ) {
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/item/dto/request/UpdateItemStatusRequestDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/dto/request/UpdateItemStatusRequestDto.java
@@ -1,0 +1,9 @@
+package com.sparta.spartatigers.domain.item.dto.request;
+
+import com.sparta.spartatigers.domain.item.model.ItemStatus;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateItemStatusRequestDto(
+    @NotNull ItemStatus status
+) {}

--- a/src/main/java/com/sparta/spartatigers/domain/item/model/Item.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/model/Item.java
@@ -156,4 +156,12 @@ public class Item extends BaseEntity {
         this.status = ItemStatus.COMPLETED;
         this.createdDate = null;
     }
+
+    public void reopen() {
+        this.status = ItemStatus.REGISTERED;
+    }
+
+    public void fail() {
+        this.status = ItemStatus.FAILED;
+    }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/item/model/Item.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/model/Item.java
@@ -70,8 +70,14 @@ public class Item extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column (name = "created_date")
+    @Column(name = "created_date")
     private LocalDate createdDate;
+
+    @Column private Double latitude;
+
+    @Column private Double longitude;
+
+    @Column private String address;
 
     @Version private Long version;
 
@@ -81,6 +87,9 @@ public class Item extends BaseEntity {
         String seatInfo,
         String title,
         String description,
+        Double latitude,
+        Double longitude,
+        String address,
         ItemStatus status,
         User user,
         LocalDate createdDate) {
@@ -90,6 +99,9 @@ public class Item extends BaseEntity {
         this.seatInfo = seatInfo;
         this.title = title;
         this.description = description;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.address = address;
         this.status = status;
         this.user = user;
         this.createdDate = createdDate;
@@ -102,6 +114,9 @@ public class Item extends BaseEntity {
             dto.seatInfo(),
             dto.title(),
             dto.description(),
+            null,
+            null,
+            null,
             ItemStatus.REGISTERED,
             user,
             LocalDate.now());

--- a/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/repository/ItemRepository.java
@@ -25,6 +25,14 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
     @Query("select i from items i where i.status = :itemStatus and i.createdDate = :createdDate and i.user.id in :nearByUserIds")
     Page<Item> findAllItems(@Param("itemStatus") ItemStatus itemStatus, @Param("createdDate") LocalDate createdDate, @Param("nearByUserIds") List<Long> nearByUserIds, Pageable pageable);
 
+    @EntityGraph(attributePaths = "user")
+    @Query("select i from items i where i.status = :itemStatus and i.createdDate = :createdDate and i.user.id = :userId")
+    Page<Item> findAllMyItems(
+        @Param("itemStatus") ItemStatus itemStatus,
+        @Param("createdDate") LocalDate createdDate,
+        @Param("userId") Long userId,
+        Pageable pageable);
+
     Optional<Item> findByIdAndStatusAndCreatedDate(Long id, ItemStatus itemStatus, LocalDate createdDate);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.spartatigers.domain.auth.model.TokenClaim;
 import com.sparta.spartatigers.domain.item.dto.request.ItemCreateRequest;
 import com.sparta.spartatigers.domain.item.dto.request.UpdateItemRequestDto;
+import com.sparta.spartatigers.domain.item.dto.request.UpdateItemStatusRequestDto;
 import com.sparta.spartatigers.domain.item.dto.response.ItemResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemDetailResponseDto;
 import com.sparta.spartatigers.domain.item.dto.response.ReadItemResponseDto;
@@ -69,6 +70,37 @@ public class ItemService {
         return ItemResponseDto.from(item);
     }
 
+    @Transactional
+    public void updateItemStatus(TokenClaim tokenClaim, Long itemId, UpdateItemStatusRequestDto request) {
+        User user = userRepository.findById(tokenClaim.getUserId())
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.VALIDATION_ERROR));
+
+        Item item = itemRepository.findById(itemId)
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ITEM_NOT_FOUND));
+        item.validateUserIsOwner(user);
+
+        if (request.status() == ItemStatus.COMPLETED) {
+            item.complete();
+            Map<String, Object> data = Map.of("itemId", item.getId(), "userId", item.getUser().getId());
+            locationService.notifyUsersNearBy(item.getUser().getId(), "REMOVE_ITEM", data);
+            return;
+        }
+
+        if (request.status() == ItemStatus.FAILED) {
+            item.reopen();
+            return;
+        }
+
+        if (request.status() == ItemStatus.DELETED) {
+            item.deleteItem();
+            Map<String, Object> data = Map.of("itemId", item.getId(), "userId", item.getUser().getId());
+            locationService.notifyUsersNearBy(item.getUser().getId(), "REMOVE_ITEM", data);
+            return;
+        }
+
+        throw new InvalidRequestException(ExceptionCode.VALIDATION_ERROR);
+    }
+
     @Transactional(readOnly = true)
     public Page<ReadItemResponseDto> findAllItems(TokenClaim tokenClaim, Pageable pageable) {
 
@@ -80,6 +112,16 @@ public class ItemService {
 
         Page<Item> itemList = itemRepository.findAllItems(ItemStatus.REGISTERED, LocalDate.now(), nearByUserIds, pageable);
 
+        return itemList.map(item -> ReadItemResponseDto.from(item, this));
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ReadItemResponseDto> findMyItems(TokenClaim tokenClaim, Pageable pageable) {
+        Long userId = userRepository.findById(tokenClaim.getUserId())
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.VALIDATION_ERROR))
+            .getId();
+
+        Page<Item> itemList = itemRepository.findAllMyItems(ItemStatus.REGISTERED, LocalDate.now(), userId, pageable);
         return itemList.map(item -> ReadItemResponseDto.from(item, this));
     }
 

--- a/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/item/service/ItemService.java
@@ -51,17 +51,31 @@ public class ItemService {
         // 이미지 URL 리스트를 JSON으로 안전하게 직렬화
         String imageUrlsJson = serializeImageUrls(imageUrls);
 
+        Double latitude = null;
+        Double longitude = null;
+        String address = null;
+
+        ItemCreateRequest.Location location = request.location();
+        if (location != null) {
+            latitude = location.latitude();
+            longitude = location.longitude();
+            address = location.address();
+        }
+
         Item item = new Item(
             request.category(),
             imageUrlsJson,
             request.seatInfo(),
             request.title(),
             request.description(),
+            latitude,
+            longitude,
+            address,
             ItemStatus.REGISTERED,
             user,
             LocalDate.now()
         );
-        
+
         itemRepository.save(item);
 
         ReadItemResponseDto newItemDto = ReadItemResponseDto.from(item, this);

--- a/src/main/java/com/sparta/spartatigers/domain/notification/controller/DeviceTokenController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/notification/controller/DeviceTokenController.java
@@ -5,10 +5,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.sparta.spartatigers.domain.auth.annotation.Auth;
 import com.sparta.spartatigers.domain.auth.model.TokenClaim;
 import com.sparta.spartatigers.domain.notification.dto.DeviceTokenRequest;
-import com.sparta.spartatigers.global.common.ApiResponse;
+import com.sparta.spartatigers.global.aop.Auth;
+import com.sparta.spartatigers.global.response.ApiResponse;
 
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
@@ -29,10 +29,6 @@ public class DeviceTokenController {
         @Auth TokenClaim tokenClaim
     ) {
         Long userId = tokenClaim.getUserId();
-
-        if (request.token() == null || request.token().isBlank()) {
-            return ApiResponse.badRequest("토큰이 비어 있습니다.");
-        }
 
         log.info(
             "[DeviceToken] userId={}, deviceType={}, tokenPrefix={}",

--- a/src/main/java/com/sparta/spartatigers/domain/notification/controller/DeviceTokenController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/notification/controller/DeviceTokenController.java
@@ -1,0 +1,49 @@
+package com.sparta.spartatigers.domain.notification.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sparta.spartatigers.domain.auth.annotation.Auth;
+import com.sparta.spartatigers.domain.auth.model.TokenClaim;
+import com.sparta.spartatigers.domain.notification.dto.DeviceTokenRequest;
+import com.sparta.spartatigers.global.common.ApiResponse;
+
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 클라이언트 디바이스(푸시) 토큰 등록용 컨트롤러.
+ * 현재 구현은 토큰 유효성을 간단히 검증하고 서버 로그에 기록만 한다.
+ * 추후 DB 저장/멀티 디바이스 지원이 필요해지면 Service/Repository 레이어를 도입한다.
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/device-tokens")
+public class DeviceTokenController {
+
+    @PostMapping
+    public ApiResponse<String> registerDeviceToken(
+        @Valid @RequestBody DeviceTokenRequest request,
+        @Auth TokenClaim tokenClaim
+    ) {
+        Long userId = tokenClaim.getUserId();
+
+        if (request.token() == null || request.token().isBlank()) {
+            return ApiResponse.badRequest("토큰이 비어 있습니다.");
+        }
+
+        log.info(
+            "[DeviceToken] userId={}, deviceType={}, tokenPrefix={}",
+            userId,
+            request.deviceType(),
+            request.token().substring(0, Math.min(request.token().length(), 20))
+        );
+
+        // TODO: 필요 시 DB에 디바이스 토큰 영구 저장 및 중복/만료 관리 추가
+
+        return ApiResponse.success("디바이스 토큰이 정상적으로 등록되었습니다.");
+    }
+}
+

--- a/src/main/java/com/sparta/spartatigers/domain/notification/dto/DeviceTokenRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/notification/dto/DeviceTokenRequest.java
@@ -1,0 +1,12 @@
+package com.sparta.spartatigers.domain.notification.dto;
+
+/**
+ * 클라이언트에서 전달하는 디바이스(푸시) 토큰 등록 요청 DTO.
+ * Java 관점에서는 단순 DTO, TypeScript의 interface와 동일한 역할을 한다.
+ */
+public record DeviceTokenRequest(
+    String token,
+    String deviceType
+) {
+}
+

--- a/src/main/java/com/sparta/spartatigers/domain/notification/dto/DeviceTokenRequest.java
+++ b/src/main/java/com/sparta/spartatigers/domain/notification/dto/DeviceTokenRequest.java
@@ -1,11 +1,13 @@
 package com.sparta.spartatigers.domain.notification.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 /**
  * 클라이언트에서 전달하는 디바이스(푸시) 토큰 등록 요청 DTO.
  * Java 관점에서는 단순 DTO, TypeScript의 interface와 동일한 역할을 한다.
  */
 public record DeviceTokenRequest(
-    String token,
+    @NotBlank(message = "디바이스 토큰은 필수입니다.") String token,
     String deviceType
 ) {
 }

--- a/src/main/java/com/sparta/spartatigers/domain/stompchat/service/ExchangeChatService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/stompchat/service/ExchangeChatService.java
@@ -62,6 +62,11 @@ public class ExchangeChatService {
                     log.warn("[sendMessage] 채팅방 없음 - roomId: {}", roomId);
                     return new InvalidRequestException(ExceptionCode.CHATROOM_NOT_FOUND);});
 
+        if (room.isCompleted()) {
+            log.warn("[sendMessage] 완료된 채팅방 전송 차단 - roomId: {}, senderId: {}", roomId, senderId);
+            throw new InvalidRequestException(ExceptionCode.FORBIDDEN_REQUEST);
+        }
+
         User sender = userRepository.findById(senderId)
                 .orElseThrow(() -> {
                         log.warn("[sendMessage] 사용자 없음 - senderId: {}", senderId);

--- a/src/main/java/com/sparta/spartatigers/domain/user/controller/UserRestController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/user/controller/UserRestController.java
@@ -23,7 +23,7 @@ public class UserRestController {
 
     private final UserService userService;
 
-    @PostMapping("/api/v1/users")
+    @PostMapping("/api/users")
     public ApiResponse<?> register(@RequestBody @Valid UserRegisterRequest request) {
         User user = request.toDomain();
         userService.addUser(user);
@@ -31,7 +31,7 @@ public class UserRestController {
         return ApiResponse.success(user);
     }
 
-    @GetMapping("/api/v1/users/me")
+    @GetMapping("/api/users/me")
     public ApiResponse<TokenClaim> me(@Auth TokenClaim tokenClaim) {
         return ApiResponse.success(tokenClaim);
     }

--- a/src/main/java/com/sparta/spartatigers/global/aop/AuthArgumentResolver.java
+++ b/src/main/java/com/sparta/spartatigers/global/aop/AuthArgumentResolver.java
@@ -35,9 +35,12 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
             WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
         String bearerToken = request.getHeader("Authorization");
-        String accessToken = bearerToken.split(" ")[1];
+        if (bearerToken == null || bearerToken.isBlank() || !bearerToken.startsWith("Bearer ")) {
+            throw new InvalidRequestException(ExceptionCode.FORBIDDEN_REQUEST);
+        }
 
-        if (accessToken == null) {
+        String accessToken = bearerToken.substring("Bearer ".length()).trim();
+        if (accessToken.isBlank()) {
             throw new InvalidRequestException(ExceptionCode.FORBIDDEN_REQUEST);
         }
 

--- a/src/main/resources/db/migration/V15__add_location_to_item.sql
+++ b/src/main/resources/db/migration/V15__add_location_to_item.sql
@@ -1,0 +1,6 @@
+-- Add location columns to items for map-based search and marker display
+ALTER TABLE items
+    ADD COLUMN latitude DOUBLE NULL,
+    ADD COLUMN longitude DOUBLE NULL,
+    ADD COLUMN address VARCHAR(255) NULL;
+


### PR DESCRIPTION
> PR 제목은 `[prefix/branch name] 내용` 형식으로 작성해주세요!
> ex) [feat/user] 회원 정보 관리 페이지 기능 구현

## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [x] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- Flyway `V15__add_location_to_item.sql` 추가로 `items` 테이블에 `latitude`, `longitude`, `address` 컬럼 도입
- `Item` 엔티티에 위치 정보 필드 및 생성자 확장, `ItemCreateRequest`에 중첩 `Location` 타입 추가로 프론트 `location` JSON 페이로드 매핑
- `ItemService.createItemWithImages`에서 DTO의 위치 정보를 읽어 아이템 생성 시 위치를 함께 저장하도록 로직 연동
- `DeviceTokenController`/`DeviceTokenRequest` 코드 스타일을 기존 컨벤션(`Auth`, `ApiResponse`, Bean Validation`)에 맞게 정리

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- 

## 💬 기타 코멘트
- 위치 정보는 현재 선택적(optional)로 처리되어 있어, 기존 클라이언트에서도 깨지지 않고 동작합니다.
- 이후 모든 아이템에 위치를 강제해야 한다면 `ItemCreateRequest.Location`에 추가적인 Validation (`@NotNull`, 범위 체크 등)을 적용하는 방향도 고려 가능합니다.
