### PR TITLE
[feat/dashboard-lineup] 대시보드 라인업 데이터 구축

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/dashboard/dto/HomeDashboardResponseDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/dashboard/dto/HomeDashboardResponseDto.java
@@ -1,5 +1,7 @@
 package com.sparta.spartatigers.domain.dashboard.dto;
 
+import java.util.List;
+import com.sparta.spartatigers.domain.liveboard.model.LineupBatter;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,4 +16,5 @@ public class HomeDashboardResponseDto {
     private Long enrollmentDays;
     private Long remainingMatches;
     private String favoriteTeamCode;
+    private List<LineupBatter> todayLineup;
 }

--- a/src/main/java/com/sparta/spartatigers/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/dashboard/service/DashboardService.java
@@ -2,13 +2,19 @@ package com.sparta.spartatigers.domain.dashboard.service;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
 
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.spartatigers.domain.dashboard.dto.HomeDashboardResponseDto;
 import com.sparta.spartatigers.domain.favoriteteam.model.entity.FavoriteTeam;
 import com.sparta.spartatigers.domain.favoriteteam.repository.FavTeamRepository;
+import com.sparta.spartatigers.domain.liveboard.dto.LineupCacheDto;
+import com.sparta.spartatigers.domain.liveboard.model.LineupBatter;
 import com.sparta.spartatigers.domain.match.model.LeagueType;
 import com.sparta.spartatigers.domain.match.model.MatchResult;
 import com.sparta.spartatigers.domain.match.repository.MatchRepository;
@@ -18,7 +24,9 @@ import com.sparta.spartatigers.global.exception.enums.ExceptionCode;
 import com.sparta.spartatigers.global.exception.internal.InvalidRequestException;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -27,38 +35,40 @@ public class DashboardService {
     private final UserRepository userRepository;
     private final MatchRepository matchRepository;
     private final FavTeamRepository favTeamRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final String LINEUP_CACHE_PREFIX = "lineup:match:";
 
     public HomeDashboardResponseDto getDashboardSummary(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new InvalidRequestException(ExceptionCode.USER_NOT_FOUND));
 
-        // 🚨 앙드레 카파시: 결정론적 시간 처리를 위해 메서드 진입점에서 시각 캡처
         LocalDateTime now = LocalDateTime.now();
 
-        // 1. 입학 일수 계산 (createdAt 기준)
+        // 1. 입학 일수 계산
         long enrollmentDays = ChronoUnit.DAYS.between(user.getCreatedAt().toLocalDate(), now.toLocalDate()) + 1;
 
-        // 2. 응원 팀 및 남은 경기 수 조회
+        // 2. 응원 팀 및 관련 정보 조회
         FavoriteTeam favTeam = favTeamRepository.findByUserId(userId).orElse(null);
         
         Long remainingMatches = 0L;
         String favoriteTeamCode = null;
+        List<LineupBatter> todayLineup = Collections.emptyList();
 
-        if (favTeam != null) {
-            // 🚨 앙드레 카파시: NPE 방어 - Team 및 Code 존재 여부 확인
-            com.sparta.spartatigers.domain.team.model.TeamCode teamCode = 
-                (favTeam.getTeam() != null && favTeam.getTeam().getCode() != null) 
-                ? favTeam.getTeam().getCode() 
-                : null;
-            
-            favoriteTeamCode = (teamCode != null) ? teamCode.name() : null;
+        if (favTeam != null && favTeam.getTeam() != null) {
+            favoriteTeamCode = (favTeam.getTeam().getCode() != null) ? favTeam.getTeam().getCode().name() : null;
 
+            // 남은 경기 수 조회
             remainingMatches = matchRepository.countRemainingMatches(
                     favTeam.getTeam().getId(),
-                    LeagueType.REGULAR, // 정규 리그 한정 집계 (의도적)
+                    LeagueType.REGULAR,
                     now,
                     MatchResult.NOT_PLAYED
             );
+
+            // 3. 오늘의 라인업 조회 (Phase 13)
+            todayLineup = fetchTodayLineup(favTeam.getTeam().getId(), now);
         }
 
         return HomeDashboardResponseDto.builder()
@@ -66,6 +76,45 @@ public class DashboardService {
                 .enrollmentDays(enrollmentDays)
                 .remainingMatches(remainingMatches)
                 .favoriteTeamCode(favoriteTeamCode)
+                .todayLineup(todayLineup)
                 .build();
+    }
+
+    /**
+     * 오늘 경기 중 해당 팀의 라인업만 추출하여 반환
+     * 🚨 앙드레 카파시: DB 부하 없이 Redis 캐시만 활용하며, 유저 응원 팀 위치(Home/Away)에 따라 필터링된 결과만 제공.
+     */
+    private List<LineupBatter> fetchTodayLineup(Long teamId, LocalDateTime now) {
+        LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
+        LocalDateTime endOfDay = startOfDay.plusDays(1);
+
+        // 오늘 진행되는 해당 팀의 정규 리그 경기 조회
+        return matchRepository.findAllByMatchTimeBetweenAndTeam(startOfDay, endOfDay, teamId, LeagueType.REGULAR)
+                .stream()
+                .findFirst()
+                .map(match -> {
+                    String cacheKey = LINEUP_CACHE_PREFIX + match.getId();
+                    Object cachedData = redisTemplate.opsForValue().get(cacheKey);
+                    
+                    if (cachedData == null) {
+                        return Collections.<LineupBatter>emptyList();
+                    }
+
+                    try {
+                        // 🚨 앙드레 카파시: ObjectMapper를 이용한 명시적 타입 변환 (안전한 역직렬화)
+                        LineupCacheDto lineupCache = objectMapper.convertValue(cachedData, LineupCacheDto.class);
+                        
+                        // 응원 팀이 홈인지 어웨이인지에 따라 필터링
+                        List<LineupBatter> lineup = match.getHomeTeam().getId().equals(teamId) 
+                                ? lineupCache.getHomeBatters() 
+                                : lineupCache.getAwayBatters();
+                                
+                        return (lineup != null) ? lineup : Collections.<LineupBatter>emptyList();
+                    } catch (Exception e) {
+                        log.error("Failed to parse lineup cache for matchId: {}", match.getId(), e);
+                        return Collections.<LineupBatter>emptyList();
+                    }
+                })
+                .orElse(Collections.emptyList());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/dashboard/service/DashboardService.java
@@ -88,10 +88,8 @@ public class DashboardService {
         LocalDateTime startOfDay = now.toLocalDate().atStartOfDay();
         LocalDateTime endOfDay = startOfDay.plusDays(1);
 
-        // 오늘 진행되는 해당 팀의 정규 리그 경기 조회
-        return matchRepository.findAllByMatchTimeBetweenAndTeam(startOfDay, endOfDay, teamId, LeagueType.REGULAR)
-                .stream()
-                .findFirst()
+        // 오늘 진행되는 해당 팀의 정규 리그 경기 조회 (최적화: LIMIT 1)
+        return matchRepository.findFirstByMatchTimeBetweenAndTeam(startOfDay, endOfDay, teamId, LeagueType.REGULAR)
                 .map(match -> {
                     String cacheKey = LINEUP_CACHE_PREFIX + match.getId();
                     Object cachedData = redisTemplate.opsForValue().get(cacheKey);

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/LiveBoardMatchSubscriber.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/LiveBoardMatchSubscriber.java
@@ -74,6 +74,7 @@ public class LiveBoardMatchSubscriber implements MessageListener {
                 // 🚨 앙드레 카파시: 안전한 역직렬화 (단순 캐스팅 금지)
                 LineupCacheDto cached = objectMapper.convertValue(existingData, LineupCacheDto.class);
                 if (newCache.equals(cached)) {
+                    log.debug("Lineup data for matchId {} is identical to existing cache, skipping update", data.getMatchId());
                     return; // 변경사항 없음
                 }
             } catch (IllegalArgumentException e) {
@@ -82,6 +83,6 @@ public class LiveBoardMatchSubscriber implements MessageListener {
         }
 
         redisTemplate.opsForValue().set(cacheKey, newCache, CACHE_TTL);
-        log.info("Lineup cache updated for matchId: {}", data.getMatchId());
+        log.info("Successfully updated lineup cache for matchId: {}", data.getMatchId());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/LiveBoardMatchSubscriber.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/LiveBoardMatchSubscriber.java
@@ -1,16 +1,21 @@
 package com.sparta.spartatigers.domain.liveboard;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sparta.spartatigers.domain.liveboard.model.LiveBoardData;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
-import java.nio.charset.StandardCharsets;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.spartatigers.domain.liveboard.dto.LineupCacheDto;
+import com.sparta.spartatigers.domain.liveboard.model.LiveBoardData;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
@@ -19,20 +24,64 @@ public class LiveBoardMatchSubscriber implements MessageListener {
 
     private final ObjectMapper objectMapper;
     private final SimpMessagingTemplate messagingTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String LINEUP_CACHE_PREFIX = "lineup:match:";
+    private static final Duration CACHE_TTL = Duration.ofHours(6);
 
     @Override
     public void onMessage(Message message, byte[] pattern) {
         try {
-            LiveBoardData liveBoardData =
-                    objectMapper.readValue(
-                            new String(message.getBody(), StandardCharsets.UTF_8),
-                            LiveBoardData.class);
+            String body = new String(message.getBody(), StandardCharsets.UTF_8);
+            LiveBoardData liveBoardData = objectMapper.readValue(body, LiveBoardData.class);
 
+            // 1. 실시간 매치 정보 STOMP 발행
             messagingTemplate.convertAndSend(
                     "/server/liveboard/room/" + liveBoardData.getMatchId() + "/match", liveBoardData);
-            log.info("/server/liveboard/room/{}/match pusehd", liveBoardData.getMatchId());
+
+            // 2. 라인업 데이터 경량화 및 캐싱 (Phase 13)
+            cacheLineupData(liveBoardData);
+
         } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            log.error("Failed to parse LiveBoardData from Redis message", e);
         }
+    }
+
+    /**
+     * 라인업 데이터를 추출하여 Redis에 경량화 캐싱
+     * 🚨 앙드레 카파시: 무거운 전체 데이터를 피하고 필요한 정보만 선별적으로 캐싱하여 메모리 절약.
+     */
+    private void cacheLineupData(LiveBoardData data) {
+        if (data.getMatchId() == null) return;
+
+        LineupCacheDto newCache = LineupCacheDto.builder()
+                .matchId(data.getMatchId())
+                .awayBatters(data.getAwayBatters())
+                .homeBatters(data.getHomeBatters())
+                .build();
+
+        // 빈 배열이거나 데이터가 아예 없는 경우 업데이트 건너뜀
+        if (!newCache.isNotEmpty()) {
+            return;
+        }
+
+        String cacheKey = LINEUP_CACHE_PREFIX + data.getMatchId();
+        
+        // 중복 쓰기 방지: 기존 데이터와 비교
+        Object existingData = redisTemplate.opsForValue().get(cacheKey);
+        if (existingData != null) {
+            try {
+                // 🚨 앙드레 카파시: 안전한 역직렬화 (단순 캐스팅 금지)
+                LineupCacheDto cached = objectMapper.convertValue(existingData, LineupCacheDto.class);
+                if (newCache.equals(cached)) {
+                    return; // 변경사항 없음
+                }
+            } catch (IllegalArgumentException e) {
+                log.warn("Failed to compare existing lineup cache, proceeding with update", e);
+            }
+        }
+
+        redisTemplate.opsForValue().set(cacheKey, newCache, CACHE_TTL);
+        log.info("Lineup cache updated for matchId: {}", data.getMatchId());
     }
 }

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/LiveBoardMatchSubscriber.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/LiveBoardMatchSubscriber.java
@@ -43,7 +43,7 @@ public class LiveBoardMatchSubscriber implements MessageListener {
             cacheLineupData(liveBoardData);
 
         } catch (JsonProcessingException e) {
-            log.error("Failed to parse LiveBoardData from Redis message", e);
+            log.error("Failed to parse LiveBoardData from Redis message: {}", e.getMessage(), e);
         }
     }
 

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/dto/LineupCacheDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/dto/LineupCacheDto.java
@@ -1,0 +1,31 @@
+package com.sparta.spartatigers.domain.liveboard.dto;
+
+import java.util.List;
+import com.sparta.spartatigers.domain.liveboard.model.LineupBatter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Redis 캐싱용 경량 라인업 DTO
+ * 🚨 앙드레 카파시: 영속성 없이 메모리 내에서만 관리되는 휘발성 데이터 객체.
+ * 무거운 전체 경기 데이터에서 라인업 정보만 추출하여 저장함으로써 메모리 효율성 극대화.
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LineupCacheDto {
+    private Long matchId;
+    private List<LineupBatter> awayBatters;
+    private List<LineupBatter> homeBatters;
+
+    /**
+     * 라인업 데이터가 유효한지(비어있지 않은지) 확인
+     */
+    public boolean isNotEmpty() {
+        return (awayBatters != null && !awayBatters.isEmpty()) || 
+               (homeBatters != null && !homeBatters.isEmpty());
+    }
+}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/dto/LineupCacheDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/dto/LineupCacheDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LineupCacheDto {
     private Long matchId;

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/dto/LineupCacheDto.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/dto/LineupCacheDto.java
@@ -2,6 +2,8 @@ package com.sparta.spartatigers.domain.liveboard.dto;
 
 import java.util.List;
 import com.sparta.spartatigers.domain.liveboard.model.LineupBatter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LineupCacheDto {
     private Long matchId;
     private List<LineupBatter> awayBatters;
@@ -24,6 +27,7 @@ public class LineupCacheDto {
     /**
      * 라인업 데이터가 유효한지(비어있지 않은지) 확인
      */
+    @JsonIgnore
     public boolean isNotEmpty() {
         return (awayBatters != null && !awayBatters.isEmpty()) || 
                (homeBatters != null && !homeBatters.isEmpty());

--- a/src/main/java/com/sparta/spartatigers/domain/match/repository/MatchRepository.java
+++ b/src/main/java/com/sparta/spartatigers/domain/match/repository/MatchRepository.java
@@ -40,6 +40,20 @@ public interface MatchRepository extends JpaRepository<Match, Long> {
 		""")
 	List<Match> findAllByMatchTimeBetweenAndTeam(LocalDateTime start, LocalDateTime end, Long teamId, LeagueType leagueType);
 
+	@Query(
+		"""
+		SELECT m
+		FROM Match m
+		JOIN FETCH m.homeTeam
+		JOIN FETCH m.awayTeam
+		LEFT JOIN FETCH m.stadium
+		WHERE m.matchTime >= :start AND m.matchTime < :end
+		  AND (m.homeTeam.id = :teamId OR m.awayTeam.id = :teamId)
+		  AND (:leagueType IS NULL OR m.leagueType = :leagueType)
+		ORDER BY m.matchTime ASC
+		""")
+	Optional<Match> findFirstByMatchTimeBetweenAndTeam(LocalDateTime start, LocalDateTime end, Long teamId, LeagueType leagueType);
+
 	List<Match> findAllByIdIn(Set<Long> ids);
 
 	@Query(


### PR DESCRIPTION
> PR 제목은 `[prefix/branch name] 내용` 형식으로 작성해주세요!
> ex) [feat/user] 회원 정보 관리 페이지 기능 구현

## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 라인업 데이터 Redis 캐싱 인프라 및 데이터 연동 기능 구현입니다

## ✅ 체크리스트
- [x] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- 

## 💬 기타 코멘트
- 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 홈 대시보드에 오늘의 라인업 정보 표시 기능이 추가되었습니다.
  * 라인업 데이터 캐싱 시스템이 구현되어 조회 성능이 개선됩니다.
  * 라이브보드에서 실시간으로 수신되는 라인업 정보가 자동으로 저장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->