### PR TITLE
feat(liveboard): matchId 기반 단일 룸 조회 API 추가

### DIFF
--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardRoomController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardRoomController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import com.sparta.spartatigers.domain.liveboard.dto.LiveBoardRoomResponseDto;
 import com.sparta.spartatigers.domain.liveboard.service.LiveboardRoomService;
@@ -45,8 +46,7 @@ public class LiveBoardRoomController {
 	}
 
 	@GetMapping("/{matchId}")
-	public ApiResponse<LiveBoardRoomResponseDto> getRoomByMatchId(
-			@org.springframework.web.bind.annotation.PathVariable Long matchId) {
+	public ApiResponse<LiveBoardRoomResponseDto> getRoomByMatchId(@PathVariable Long matchId) {
 		return ApiResponse.success(liveboardRoomService.getRoomByMatchId(matchId));
 	}
 

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardRoomController.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/controller/LiveBoardRoomController.java
@@ -28,8 +28,7 @@ public class LiveBoardRoomController {
 
 	@PostMapping
 	public ApiResponse<String> createRoomsForDay(
-		@RequestParam (required = false)
-		@DateTimeFormat(pattern = "yyyyMMdd") LocalDate anyday) {
+			@RequestParam(required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate anyday) {
 		if (anyday == null) {
 			anyday = LocalDate.now(clock);
 		}
@@ -38,18 +37,22 @@ public class LiveBoardRoomController {
 
 	@GetMapping
 	public List<LiveBoardRoomResponseDto> getRoomsForDay(
-		@RequestParam (required = false)
-		@DateTimeFormat(pattern = "yyyyMMdd") LocalDate anyday) {
+			@RequestParam(required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate anyday) {
 		if (anyday == null) {
 			anyday = LocalDate.now(clock);
 		}
 		return liveboardRoomService.getRoomsForDay(anyday);
 	}
 
+	@GetMapping("/{matchId}")
+	public ApiResponse<LiveBoardRoomResponseDto> getRoomByMatchId(
+			@org.springframework.web.bind.annotation.PathVariable Long matchId) {
+		return ApiResponse.success(liveboardRoomService.getRoomByMatchId(matchId));
+	}
+
 	@DeleteMapping
 	public ApiResponse<String> deleteRoomsForDay(
-		@RequestParam (required = false)
-		@DateTimeFormat(pattern = "yyyyMMdd") LocalDate anyday) {
+			@RequestParam(required = false) @DateTimeFormat(pattern = "yyyyMMdd") LocalDate anyday) {
 		if (anyday == null) {
 			anyday = LocalDate.now(clock);
 		}

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveboardRoomService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveboardRoomService.java
@@ -161,6 +161,45 @@ public class LiveboardRoomService {
 	}
 
 
+	public LiveBoardRoomResponseDto getRoomByMatchId(Long matchId) {
+		Match match = matchRepository.findByMatchId(matchId)
+			.orElseThrow(() -> new com.sparta.spartatigers.global.exception.internal.InvalidRequestException(
+				com.sparta.spartatigers.global.exception.enums.ExceptionCode.MATCH_NOT_FOUND));
+
+		String roomId = "LIVEBOARD_" + matchId;
+		LiveBoardRoom room = roomRepository.findRoomById(roomId);
+
+		LocalDate matchDate = match.getMatchTime().toLocalDate();
+		LocalDate realToday = LocalDateTime.now(clock).toLocalDate();
+
+		if (matchDate.isEqual(realToday)) {
+			long connectCount = (room != null) ? connectionRepository.getConnectionCount(room.getRoomId()) : 0L;
+			Stadium stadium = match.getStadium();
+			
+			NowCastResponseDto nowCast = null;
+			List<ForeCastResponseDto> foreCast = null;
+			
+			if (stadium != null) {
+				nowCast = weatherService.getNowCast(stadium.getId());
+				foreCast = weatherService.getForeCast(stadium.getId());
+			}
+
+			// 룸이 아직 생성되지 않았더라도(드문 경우) Match 정보를 기반으로 TODAY 응답 생성 가능
+			if (room == null) {
+				return LiveBoardRoomResponseDto.fromTodayMatch(match, LiveBoardRoom.of(roomId, matchId, match.getAwayTeam().getName() + "VS" + match.getHomeTeam().getName(), match.getMatchTime()), 0L, nowCast, foreCast);
+			}
+			return LiveBoardRoomResponseDto.fromTodayMatch(match, room, connectCount, nowCast, foreCast);
+		} else if (matchDate.isBefore(realToday)) {
+			if (room == null) {
+				// 과거 경기인데 룸이 없다면 기본 정보로 생성해서 반환 (일관성)
+				return LiveBoardRoomResponseDto.fromPastMatch(match, LiveBoardRoom.of(roomId, matchId, "PAST_MATCH", match.getMatchTime()));
+			}
+			return LiveBoardRoomResponseDto.fromPastMatch(match, room);
+		} else {
+			return LiveBoardRoomResponseDto.fromUpcomingMatch(match);
+		}
+	}
+
 	// ✅분리 메서드 - 경기별로 룸 하나씩 생성
 	private LiveBoardRoom createRoom(Match match) {
 		String roomId = "LIVEBOARD_" + match.getId();

--- a/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveboardRoomService.java
+++ b/src/main/java/com/sparta/spartatigers/domain/liveboard/service/LiveboardRoomService.java
@@ -23,6 +23,8 @@ import com.sparta.spartatigers.domain.liveboard.model.Stadium;
 import com.sparta.spartatigers.domain.weather.dto.ForeCastResponseDto;
 import com.sparta.spartatigers.domain.weather.dto.NowCastResponseDto;
 import com.sparta.spartatigers.domain.weather.service.WeatherService;
+import com.sparta.spartatigers.global.exception.enums.ExceptionCode;
+import com.sparta.spartatigers.global.exception.internal.InvalidRequestException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,21 +48,21 @@ public class LiveboardRoomService {
 		List<Match> dayOfMatches = matchRepository.findAllByMatchTimeBetween(start, end);
 
 		// 2. 오늘 경기가 없다면 return
-		if(dayOfMatches.isEmpty()) {
+		if (dayOfMatches.isEmpty()) {
 			return "[LIVEBOARD/ROOM] " + day + " | NO_MATCHES";
 		}
 
 		// 3. 매치ID들을 모아서 room 레파지토리에 기존재하는지 찾기
-		Set<Long> matchIds
-			= dayOfMatches.stream().map(Match::getId).collect(Collectors.toSet());
-		Set<Long> alreadyCreated
-			= roomRepository.findAllByMatchIdIn(matchIds).stream().map(LiveBoardRoom::getMatchId).collect(Collectors.toSet());
+		Set<Long> matchIds = dayOfMatches.stream().map(Match::getId).collect(Collectors.toSet());
+		Set<Long> alreadyCreated = roomRepository.findAllByMatchIdIn(matchIds).stream().map(LiveBoardRoom::getMatchId)
+				.collect(Collectors.toSet());
 
 		// 4. 룸 생성 로직
 		int createdCount = 0;
-		for(Match match : dayOfMatches) {
+		for (Match match : dayOfMatches) {
 			// 4-1. 매치ID에 대해 룸이 이미 생성되어 있다면 SKIP
-			if (alreadyCreated.contains(match.getId())) continue;
+			if (alreadyCreated.contains(match.getId()))
+				continue;
 			// 4-2.룸이 존재하지 않고, 결과가 NOT_PLAYED일때만 생성
 			if (MatchResult.NOT_PLAYED.equals(match.getMatchResult())) {
 				createRoom(match);
@@ -71,14 +73,15 @@ public class LiveboardRoomService {
 		// 5. string으로 응답
 		long totalRoomsToday = roomRepository.findAllByDate(anyday).size();
 		long creatableCount = dayOfMatches.stream()
-			.filter(match -> MatchResult.NOT_PLAYED.equals(match.getMatchResult()))
-			.filter(m -> !alreadyCreated.contains(m.getId()))
-			.count();
+				.filter(match -> MatchResult.NOT_PLAYED.equals(match.getMatchResult()))
+				.filter(m -> !alreadyCreated.contains(m.getId()))
+				.count();
 
-		if(createdCount == 0) {
+		if (createdCount == 0) {
 			return "[LIVEBOARD/ROOM] " + day + " | ALREADY_CREATED" + " | TOTAL : " + totalRoomsToday;
 		} else if (createdCount < creatableCount) {
-			return "[LIVEBOARD/ROOM] " + day + " | PARTIALLY_CREATED : " + createdCount + " | TOTAL : " + totalRoomsToday;
+			return "[LIVEBOARD/ROOM] " + day + " | PARTIALLY_CREATED : " + createdCount + " | TOTAL : "
+					+ totalRoomsToday;
 		} else {
 			return "[LIVEBOARD/ROOM] " + day + " | CREATED : " + createdCount + " | TOTAL : " + totalRoomsToday;
 		}
@@ -90,38 +93,38 @@ public class LiveboardRoomService {
 		List<Match> dayOfMatches = matchRepository.findAllByMatchTimeBetween(start, end);
 
 		Map<Long, LiveBoardRoom> roomMap = roomRepository.findAllByDate(anyday).stream()
-			.collect(Collectors.toMap(LiveBoardRoom::getMatchId, Function.identity()));
+				.collect(Collectors.toMap(LiveBoardRoom::getMatchId, Function.identity()));
 
-		List<LiveBoardRoomResponseDto> roomDtosForDay =
-			dayOfMatches.stream()
+		List<LiveBoardRoomResponseDto> roomDtosForDay = dayOfMatches.stream()
 				.map(match -> {
-				LiveBoardRoom room = roomMap.get(match.getId());
+					LiveBoardRoom room = roomMap.get(match.getId());
 
-				if(room == null) {
-					return LiveBoardRoomResponseDto.fromUpcomingMatch(match);
-				}
-
-				LocalDate matchDate = match.getMatchTime().toLocalDate();
-				LocalDate realToday = LocalDateTime.now(clock).toLocalDate();
-
-				if(matchDate.isEqual(realToday)) { // 당일 경기
-					long connectCount = connectionRepository.getConnectionCount(room.getRoomId());
-
-					Stadium stadium = match.getStadium();
-					if (stadium == null) {
-						log.warn("[ROOM] Stadium info missing for Match ID: {}. Skipping weather info.", match.getId());
-						return LiveBoardRoomResponseDto.fromTodayMatch(match, room, connectCount, null, null);
+					if (room == null) {
+						return LiveBoardRoomResponseDto.fromUpcomingMatch(match);
 					}
 
-					NowCastResponseDto nowCast = weatherService.getNowCast(stadium.getId());
-					List<ForeCastResponseDto> foreCast = weatherService.getForeCast(stadium.getId());
-					return LiveBoardRoomResponseDto.fromTodayMatch(match, room, connectCount, nowCast, foreCast);
-				} else if (matchDate.isBefore(realToday)) { // 지난 경기
-					return LiveBoardRoomResponseDto.fromPastMatch(match, room);
-				} else { // 그외의 예정 경기
-					return LiveBoardRoomResponseDto.fromUpcomingMatch(match);
-				}
-			}).toList();
+					LocalDate matchDate = match.getMatchTime().toLocalDate();
+					LocalDate realToday = LocalDateTime.now(clock).toLocalDate();
+
+					if (matchDate.isEqual(realToday)) { // 당일 경기
+						long connectCount = connectionRepository.getConnectionCount(room.getRoomId());
+
+						Stadium stadium = match.getStadium();
+						if (stadium == null) {
+							log.warn("[ROOM] Stadium info missing for Match ID: {}. Skipping weather info.",
+									match.getId());
+							return LiveBoardRoomResponseDto.fromTodayMatch(match, room, connectCount, null, null);
+						}
+
+						NowCastResponseDto nowCast = weatherService.getNowCast(stadium.getId());
+						List<ForeCastResponseDto> foreCast = weatherService.getForeCast(stadium.getId());
+						return LiveBoardRoomResponseDto.fromTodayMatch(match, room, connectCount, nowCast, foreCast);
+					} else if (matchDate.isBefore(realToday)) { // 지난 경기
+						return LiveBoardRoomResponseDto.fromPastMatch(match, room);
+					} else { // 그외의 예정 경기
+						return LiveBoardRoomResponseDto.fromUpcomingMatch(match);
+					}
+				}).toList();
 
 		return roomDtosForDay;
 	}
@@ -130,7 +133,7 @@ public class LiveboardRoomService {
 		// 1. 삭제할 날짜의 Room 선택
 		String day = anyday.format(DateTimeFormatter.ofPattern("MM/dd"));
 		List<LiveBoardRoom> roomsToDelete = roomRepository.findAllByDate(anyday);
-		if(roomsToDelete.isEmpty()) {
+		if (roomsToDelete.isEmpty()) {
 			return "[LIVEBOARD/ROOM] " + day + " | NO_ROOMS_FOUND";
 		}
 
@@ -141,15 +144,17 @@ public class LiveboardRoomService {
 		List<Match> matches = matchRepository.findAllByIdIn(matchIds);
 		Map<Long, Match> matchMap = matches.stream().collect(Collectors.toMap(Match::getId, Function.identity()));
 
-		for(LiveBoardRoom room : roomsToDelete) {
+		for (LiveBoardRoom room : roomsToDelete) {
 			Match match = matchMap.get(room.getMatchId());
-			if(match == null) continue;
+			if (match == null)
+				continue;
 
-			if(MatchResult.NOT_PLAYED.equals(match.getMatchResult())) continue;
+			if (MatchResult.NOT_PLAYED.equals(match.getMatchResult()))
+				continue;
 
 			roomRepository.deleteRoom(room.getRoomId());
 			connectionRepository.deleteAllConnections(room.getRoomId());
-			deletedCount ++;
+			deletedCount++;
 		}
 		long totalRoomsLeft = roomRepository.findAllByDate(anyday).size();
 
@@ -160,11 +165,9 @@ public class LiveboardRoomService {
 		}
 	}
 
-
 	public LiveBoardRoomResponseDto getRoomByMatchId(Long matchId) {
 		Match match = matchRepository.findByMatchId(matchId)
-			.orElseThrow(() -> new com.sparta.spartatigers.global.exception.internal.InvalidRequestException(
-				com.sparta.spartatigers.global.exception.enums.ExceptionCode.MATCH_NOT_FOUND));
+				.orElseThrow(() -> new InvalidRequestException(ExceptionCode.MATCH_NOT_FOUND));
 
 		String roomId = "LIVEBOARD_" + matchId;
 		LiveBoardRoom room = roomRepository.findRoomById(roomId);
@@ -175,10 +178,10 @@ public class LiveboardRoomService {
 		if (matchDate.isEqual(realToday)) {
 			long connectCount = (room != null) ? connectionRepository.getConnectionCount(room.getRoomId()) : 0L;
 			Stadium stadium = match.getStadium();
-			
+
 			NowCastResponseDto nowCast = null;
 			List<ForeCastResponseDto> foreCast = null;
-			
+
 			if (stadium != null) {
 				nowCast = weatherService.getNowCast(stadium.getId());
 				foreCast = weatherService.getForeCast(stadium.getId());
@@ -186,13 +189,16 @@ public class LiveboardRoomService {
 
 			// 룸이 아직 생성되지 않았더라도(드문 경우) Match 정보를 기반으로 TODAY 응답 생성 가능
 			if (room == null) {
-				return LiveBoardRoomResponseDto.fromTodayMatch(match, LiveBoardRoom.of(roomId, matchId, match.getAwayTeam().getName() + "VS" + match.getHomeTeam().getName(), match.getMatchTime()), 0L, nowCast, foreCast);
+				return LiveBoardRoomResponseDto.fromTodayMatch(match, LiveBoardRoom.of(roomId, matchId,
+						match.getAwayTeam().getName() + "VS" + match.getHomeTeam().getName(), match.getMatchTime()), 0L,
+						nowCast, foreCast);
 			}
 			return LiveBoardRoomResponseDto.fromTodayMatch(match, room, connectCount, nowCast, foreCast);
 		} else if (matchDate.isBefore(realToday)) {
 			if (room == null) {
 				// 과거 경기인데 룸이 없다면 기본 정보로 생성해서 반환 (일관성)
-				return LiveBoardRoomResponseDto.fromPastMatch(match, LiveBoardRoom.of(roomId, matchId, "PAST_MATCH", match.getMatchTime()));
+				return LiveBoardRoomResponseDto.fromPastMatch(match,
+						LiveBoardRoom.of(roomId, matchId, "PAST_MATCH", match.getMatchTime()));
 			}
 			return LiveBoardRoomResponseDto.fromPastMatch(match, room);
 		} else {


### PR DESCRIPTION
> PR 제목은 `[prefix/branch name] 내용` 형식으로 작성해주세요!
> ex) [feat/user] 회원 정보 관리 페이지 기능 구현

## 📌 PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 리팩토링 / 수정
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 업데이트

## 💡 구현 내용 요약
- 클라이언트사이드 필터링 비효율을 해결하기 위해 matchId 기반 엔드포인트 구현
- 경기 일시에 따른 PAST, TODAY, UPCOMING 상태 결정론적 처리 로직 적용
- TODAY 상태인 경우 구장 날씨 및 접속자 수 자동 포함

## ✅ 체크리스트
- [ ] 테스트 완료
- [ ] 코드 리뷰 반영
- [ ] 관련 문서 수정

## 🔗 관련 이슈
- 

## 💬 기타 코멘트
- 

